### PR TITLE
feat: add full-graph DFlash2 speculative decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ python python/sfllm/serving/app.py \
 ```bash
 python python/sfllm/serving/app.py \
   --model /path/to/your/model \
-  --draft-model-path /path/to/eagle3/draft/model \
+  --speculative-draft-model-path /path/to/eagle3/draft/model \
   --speculative-algorithm eagle3 \
   --speculative-num-steps 4 \
   --port 8081 \
@@ -114,8 +114,8 @@ curl http://localhost:8081/health
 | `--max-context-length` | Maximum context length | 4096 |
 | `--cuda-graph-max-bs` | Max CUDA graph batch size | 32 |
 | `--disable-cuda-graph` | Disable CUDA graphs | False |
-| `--speculative-algorithm` | Speculative decoding algorithm (eagle3) | None |
-| `--draft-model-path` | Path to Eagle3 draft model | None |
+| `--speculative-algorithm` | Speculative decoding algorithm (`eagle3` or `dflash2`) | None |
+| `--speculative-draft-model-path` | Path to the speculative draft model | None |
 | `--speculative-num-steps` | Number of speculative steps | 4 |
 | `--disable-overlap` | Disable overlap scheduling | False |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -58,7 +58,7 @@ python python/sfllm/serving/app.py \
 ```bash
 python python/sfllm/serving/app.py \
   --model /path/to/your/model \
-  --draft-model-path /path/to/eagle3/draft/model \
+  --speculative-draft-model-path /path/to/eagle3/draft/model \
   --speculative-algorithm eagle3 \
   --speculative-num-steps 4 \
   --port 8081 \
@@ -110,8 +110,8 @@ curl http://localhost:8081/health
 | `--max-context-length` | 最大上下文长度 | 4096 |
 | `--cuda-graph-max-bs` | CUDA图最大批处理大小 | 32 |
 | `--disable-cuda-graph` | 禁用CUDA图 | False |
-| `--speculative-algorithm` | 投机解码算法 (eagle3) | None |
-| `--draft-model-path` | Eagle3草稿模型路径 | None |
+| `--speculative-algorithm` | 投机解码算法 (`eagle3` 或 `dflash2`) | None |
+| `--speculative-draft-model-path` | 投机解码草稿模型路径 | None |
 | `--speculative-num-steps` | 投机解码步数 | 4 |
 | `--disable-overlap` | 禁用重叠调度 | False |
 

--- a/docs/dflash2-design.md
+++ b/docs/dflash2-design.md
@@ -1,0 +1,92 @@
+# DFlash2 design
+
+## Boundary
+
+DFlash2 is a draft proposer plugged into SFLLM's existing Eagle3 speculative
+pipeline. Algorithm selection happens once in `InferenceEngine`. From that
+point onward the scheduler, overlap loop, CUDA Graph runner, verify,
+postprocess, and KV lifetime logic are shared.
+
+| Shared with Eagle3 | DFlash2-specific |
+| --- | --- |
+| `ScheduleBatch` speculative metadata | DFlash2 checkpoint/model definition |
+| `EagleSpecInput` and `EagleVerifyInput` | target-hidden to draft-KV projection |
+| target verify and greedy acceptance | fixed masked-block draft forward |
+| accepted-token/KV packing | block-local convolution and candidate selector |
+| overlap placeholders and KV ownership | linear Eagle verify topology adapter |
+| `SpeculativeE2ECudaGraphRunner` | |
+
+There is no DFlash2 request state, scheduler branch, delayed-release protocol,
+accept kernel, pack kernel, or graph runner.
+
+## Decode
+
+For block size `B`, one DFlash2 decode graph performs:
+
+1. Materialize the previous accepted target contexts into the draft KV slots
+   prepared by the shared speculative scheduler.
+2. Build `[anchor, MASK, ..., MASK]` and its consecutive positions.
+3. Run the non-causal DFlash2 draft block against the committed draft prefix.
+4. Apply DFlash2's block-local dynamic convolutions around each attention/MLP
+   sublayer, then use the target LM head to form top-k unary candidates, score
+   adjacent candidate transitions, and choose one linear path of `B - 1`
+   proposals.
+5. Represent `[anchor, proposals...]` as a linear `EagleVerifyInput` and call
+   the shared target verify/accept path.
+6. Project the captured target hidden states into the shared Eagle hidden-state
+   buffer for the next overlapped step.
+
+The entire steady-state sequence above is the callback captured by
+`SpeculativeE2ECudaGraphRunner`. Host-side overlap ordering and cache ownership are
+therefore exactly the Eagle3 ordering.
+
+Prefill is the only different entry path: the target performs normal prefill,
+then its captured hidden states are projected directly into draft KV. The
+result is published as `EagleSpecInput`, so all following steps use the shared
+pipeline.
+
+## Supported checkpoint contract
+
+The current model backend supports Qwen3-family target and draft configs with
+dense weights and greedy decoding. Dimensions are read from the checkpoint;
+Qwen3-4B is the initial validated model, not a hard-coded shape.
+
+DFlash2 fields live under `dflash_config`:
+
+- `block_size`
+- `mask_token_id`
+- `selector_rank`
+- `selector_top_k`
+- `target_layer_ids`
+
+The initializer preserves the trained DFlash tensors, initializes each new
+convolution from an identity base plus random dynamic projection, and randomly
+initializes the selector tensors:
+
+```bash
+.venv/bin/python scripts/initialize_dflash2_checkpoint.py \
+  --source z-lab/Qwen3-4B-DFlash-b16 \
+  --output /path/to/dflash2-checkpoint \
+  --selector-rank 256 \
+  --selector-top-k 16 \
+  --seed 0
+```
+
+## Validation
+
+Validation is offline only. `scripts/validate_dflash2_offline.py` checks that
+each request produces exactly its requested token count, all token IDs are in
+the target vocabulary, every decode replay has a captured batch-size graph,
+and target/draft KV usage returns to its pre-request baseline. It also prints
+token/text previews so generation can be inspected directly.
+
+Node-level CUDA Graph coverage is checked separately with `nsys profile` and
+`--cuda-graph-trace=node`. A valid steady-state profile has one
+`cudaGraphLaunch` per decode step, with the DFlash2 block preparation, selector,
+draft forward, target verify, acceptance, and KV-materialization kernels all
+reported as graph nodes rather than standalone launches.
+
+The helper does not claim bitwise target-only or eager parity. Target verify
+uses a batched extend kernel while target-only decoding uses a decode kernel;
+with BF16, near-tied logits can therefore choose different argmax tokens even
+when speculative acceptance is correct.

--- a/docs/dflash2-design.md
+++ b/docs/dflash2-design.md
@@ -59,26 +59,16 @@ DFlash2 fields live under `dflash_config`:
 - `selector_top_k`
 - `target_layer_ids`
 
-The initializer preserves the trained DFlash tensors, initializes each new
-convolution from an identity base plus random dynamic projection, and randomly
-initializes the selector tensors:
-
-```bash
-.venv/bin/python scripts/initialize_dflash2_checkpoint.py \
-  --source z-lab/Qwen3-4B-DFlash-b16 \
-  --output /path/to/dflash2-checkpoint \
-  --selector-rank 256 \
-  --selector-top-k 16 \
-  --seed 0
-```
+The validated checkpoint preserves the trained DFlash tensors, initializes
+each new convolution from an identity base plus random dynamic projection, and
+randomly initializes the selector tensors.
 
 ## Validation
 
-Validation is offline only. `scripts/validate_dflash2_offline.py` checks that
-each request produces exactly its requested token count, all token IDs are in
-the target vocabulary, every decode replay has a captured batch-size graph,
-and target/draft KV usage returns to its pre-request baseline. It also prints
-token/text previews so generation can be inspected directly.
+Validation is offline only. It checks that each request produces exactly its
+requested token count, all token IDs are in the target vocabulary, every
+decode replay has a captured batch-size graph, and target/draft KV usage
+returns to its pre-request baseline.
 
 Node-level CUDA Graph coverage is checked separately with `nsys profile` and
 `--cuda-graph-trace=node`. A valid steady-state profile has one

--- a/python/example/batch_offline.py
+++ b/python/example/batch_offline.py
@@ -1,16 +1,19 @@
+"""Run batched offline inference with a base, Eagle3, or DFlash2 model."""
+
 import argparse
+
+import tqdm
+
 from sfllm.engine.inference_engine import InferenceEngine
 from sfllm.engine.sampling_params import SamplingParams
 from sfllm.server_args import ServerArgs
-import tqdm
 
 if __name__ == "__main__":
-    # Example usage
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     ServerArgs.add_cli_args(parser)
+    parser.add_argument("--max-new-tokens", type=int, default=200)
     args = parser.parse_args()
     server_args = ServerArgs.from_cli_args(args)
-    # server_args.disable_cuda_graph = True
     engine = InferenceEngine(server_args)
     prompts = [
         "Hello, my name is",
@@ -26,12 +29,18 @@ if __name__ == "__main__":
     ]
     # engine.add_request("Hello, world!", SamplingParams())
     outputs = engine.generate(
-        prompts, SamplingParams(max_new_tokens=200, top_k=1), stream=False
+        prompts,
+        SamplingParams(max_new_tokens=args.max_new_tokens, top_k=1),
+        stream=False,
     )
     for output in tqdm.tqdm(outputs):
         for _, output_d in output.items():
             v = f"Prompt: {output_d['prompt']}\nGenerated text: {output_d['text']}"
-            # print(v)
-    print(engine.scheduler.metrics.cum_spec_accept_tokens-
-          engine.scheduler.metrics.cum_forward_ct)
+            print(v)
+    if server_args.speculative_algorithm is not None:
+        extra_accepted = (
+            engine.scheduler.metrics.cum_spec_accept_tokens
+            - engine.scheduler.metrics.cum_forward_ct
+        )
+        print(f"Speculative extra accepted tokens: {extra_accepted}")
     print("Inference step completed.")

--- a/python/sfllm/engine/inference_engine.py
+++ b/python/sfllm/engine/inference_engine.py
@@ -11,6 +11,7 @@ import queue
 from typing import Dict, Any, List, Tuple, Generator, Union
 
 from sfllm.engine.model_worker import ModelWorker
+from sfllm.spec_decoding.dflash2_worker import DFlash2Worker
 from sfllm.spec_decoding.eagle_worker import EagleWorker
 from sfllm.engine.scheduler import Scheduler
 from sfllm.engine.sampling_params import SamplingParams
@@ -30,7 +31,12 @@ class InferenceEngine:
         Initialize the inference worker.
         """
         configure_logger(server_args)
-        self.model_worker = ModelWorker(server_args) if server_args.speculative_algorithm != "eagle3" else EagleWorker(server_args)
+        if server_args.speculative_algorithm == "eagle3":
+            self.model_worker = EagleWorker(server_args)
+        elif server_args.speculative_algorithm == "dflash2":
+            self.model_worker = DFlash2Worker(server_args)
+        else:
+            self.model_worker = ModelWorker(server_args)
         self.server_args = server_args
         self.running = False
         self.scheduler = Scheduler(server_args, self.model_worker)
@@ -64,6 +70,19 @@ class InferenceEngine:
         
         valid_ids = set(range(len(schedule_batch)))
         for idx, sequence in enumerate(schedule_batch):
+            if self.is_spec_algo:
+                committed_tokens = token_ids[
+                    cum_token_cnts[idx] : cum_token_cnts[idx + 1]
+                ]
+                generated_count = (
+                    sequence.last_generated_token_pos - sequence.prompt_token_len
+                )
+                remaining_tokens = max(
+                    sequence.sampling_params.max_new_tokens - generated_count,
+                    0,
+                )
+                committed_tokens = committed_tokens[:remaining_tokens]
+
             if self.enable_overlap:
                 if sequence.status.is_active():
                     assert sequence.tokens[sequence.last_generated_token_pos] < 0, (
@@ -72,11 +91,12 @@ class InferenceEngine:
                     assert token_ids[idx] >= 0, "Generated token should be valid"
                     if self.is_spec_algo:
                         draft_token_steps = self.server_args.speculative_num_steps+1
-                        new_token = token_ids[cum_token_cnts[idx]: cum_token_cnts[idx + 1]]
                         last_pos = sequence.last_generated_token_pos
-                        sequence.tokens[last_pos:last_pos+len(new_token)] = new_token
-                        sequence.tokens[last_pos+len(new_token): last_pos+draft_token_steps] = []
-                        sequence.generated_tokens = new_token
+                        sequence.tokens[last_pos:last_pos+len(committed_tokens)
+                        ] = committed_tokens
+                        sequence.tokens[last_pos + len(committed_tokens) : last_pos + draft_token_steps
+                        ] = []
+                        sequence.generated_tokens = committed_tokens
                         sequence.last_generated_token_pos += len(sequence.generated_tokens)
                     else:
                         sequence.tokens[sequence.last_generated_token_pos] = token_ids[idx]
@@ -84,7 +104,7 @@ class InferenceEngine:
                         sequence.last_generated_token_pos += 1
             else:
                 if self.is_spec_algo:
-                    sequence.new_tokens = token_ids[cum_token_cnts[idx]: cum_token_cnts[idx + 1]]
+                    sequence.new_tokens = committed_tokens
                     sequence.generated_tokens = sequence.new_tokens.copy()
                     sequence.tokens.extend(sequence.new_tokens)
                     sequence.last_generated_token_pos += len(sequence.generated_tokens)
@@ -179,7 +199,9 @@ class InferenceEngine:
             future_token_stride = draft_token_steps
             target_mem_pool = self.scheduler.mem_pool
             draft_mem_pool = self.scheduler.draft_memory_pool
-            hidden_size = self.server_args.model_config.hidden_size*3
+            hidden_size = (
+                self.model_worker.draft_model_runner.model.speculative_hidden_size
+            )
             dtype = self.model_worker.dtype
             hidden_states_buf = torch.empty((128, draft_token_steps, hidden_size), device=device_id, dtype=dtype)
 
@@ -233,6 +255,10 @@ class InferenceEngine:
                         cur_batch.forward_batch.mask_indptr[1:] = cum_seq_mask_len
                         #####
                         x = cur_batch.forward_batch_spec.kv_indices_mtd
+                        # These staging tensors were allocated on scheduler_stream
+                        # and lose their last reference when replaced below.
+                        # Keep their storage alive through compute-side compaction.
+                        x.record_stream(compute_stream)
                         if cur_batch.spec_info.out_cache_loc is not None:
                             b = cur_batch.forward_batch_spec.kv_indptr
                         else:
@@ -281,9 +307,11 @@ class InferenceEngine:
                         cur_batch.forward_batch.kv_indptr[1:] -= cum_extra_length
 
                         x = cur_batch.forward_batch_spec.position_ids_extend
+                        x.record_stream(compute_stream)
                         b = torch.arange(0, (len(cur_batch)+1)*draft_token_steps, draft_token_steps, device=device_id)
                         cur_batch.forward_batch_spec.position_ids_extend = compact_accepted_tokens(x, b, accept_length, fill_value=0)
                         x = cur_batch.forward_batch_spec.out_cache_loc
+                        x.record_stream(compute_stream)
                         cur_batch.forward_batch_spec.out_cache_loc = compact_accepted_tokens(x, b, accept_length, fill_value=0)
                         if cur_batch.spec_info.verified_id.shape[0] != cur_batch.forward_batch_spec.position_ids_extend.shape[0]:
                             token_len = cur_batch.spec_info.verified_id.shape[0]

--- a/python/sfllm/engine/memory_pool.py
+++ b/python/sfllm/engine/memory_pool.py
@@ -43,7 +43,7 @@ class BlockMemoryManager:
         self.num_blocks = num_blocks
         self.num_blocks, self.block_shape = self.get_num_blocks(server_args)
         self.blocks = [BlockMemory(i) for i in range(self.num_blocks)]
-        self.free_block_ids = list(range(1, self.num_blocks))
+        self.free_block_ids = deque(range(1, self.num_blocks))
         self.release_block_ids = []
         self.used_block_ids = set([])
         self.kv_buffers = []
@@ -117,14 +117,19 @@ class BlockMemoryManager:
         return len(self.free_block_ids) >= token_len
 
     def persist_alloc_block_from_rear(self, num_tokens: int) -> List[int]:
-        popped = self.free_block_ids[-num_tokens:]
-        self.free_block_ids = self.free_block_ids[:-num_tokens]
+        popped = [
+            self.free_block_ids.pop()
+            for _ in range(min(num_tokens, len(self.free_block_ids)))
+        ]
+        popped.reverse()
         return popped
 
     def alloc_block(self, token_nums: int) -> List[int]:
         """Allocate a block of memory."""
-        block_ids = self.free_block_ids[:token_nums]
-        self.free_block_ids = self.free_block_ids[token_nums:]
+        block_ids = [
+            self.free_block_ids.popleft()
+            for _ in range(min(token_nums, len(self.free_block_ids)))
+        ]
         self.used_block_ids.update(block_ids)
         return block_ids
 

--- a/python/sfllm/engine/model_runner.py
+++ b/python/sfllm/engine/model_runner.py
@@ -52,8 +52,15 @@ class ModelRunner:
         self.dtype = self.model.dtype
         self.server_args = server_args
 
-        expand_scale = (server_args.speculative_num_steps * server_args.speculative_eagle_topk 
-                        if is_draft else server_args.speculative_num_draft_tokens)
+        draft_token_width = max(
+            server_args.speculative_num_steps * server_args.speculative_eagle_topk,
+            server_args.speculative_num_steps + 1,
+        )
+        expand_scale = (
+            draft_token_width
+            if is_draft
+            else server_args.speculative_num_draft_tokens
+        )
         max_batch_size = server_args.cuda_graph_max_bs*expand_scale
         self.input_ids = torch.empty((max_batch_size,), dtype=torch.long, device=self.device_id)
         self.position_ids = torch.empty((max_batch_size,), dtype=torch.long, device=self.device_id)
@@ -110,9 +117,14 @@ class ModelRunner:
         self.capture_batch_size = DEFAULT_CUDA_GRAPH_BATCH_SIZES[:ind]
         self.capture_batch_size = self.capture_batch_size[:ind]
 
-        expand_scale = self.server_args.speculative_num_steps* self.server_args.speculative_eagle_topk if self.is_draft else 1
-        max_batch_size = max(self.capture_batch_size)*expand_scale
-        # for draft extend, out_cache_loc size = batch_size * speculative_num_steps*topk
+        max_capture_batch_size = self.cuda_graph_max_bs
+        metadata_expand_scale = (
+            self.server_args.speculative_num_steps
+            * self.server_args.speculative_eagle_topk
+            if self.is_draft
+            else 1
+        )
+        max_batch_size = max_capture_batch_size * metadata_expand_scale
         self.output_logits = {}
         self.output_logits_target_verify = {}
         self.output_logits_extend = {}
@@ -129,9 +141,13 @@ class ModelRunner:
 
         if self.is_draft:
             self.hidden_states_buffer = torch.empty(
-                (max_batch_size*(self.server_args.speculative_num_steps+1), self.get_config().hidden_size*3),
+                (
+                    max_capture_batch_size
+                    * (self.server_args.speculative_num_steps + 1),
+                    self.model.speculative_hidden_size,
+                ),
                 dtype=self.dtype,
-                device=self.device_id
+                device=self.device_id,
             )
 
     def init_capture_cudagraph(self, forward_mode: ForwardMode = ForwardMode.DECODE):

--- a/python/sfllm/engine/scheduler.py
+++ b/python/sfllm/engine/scheduler.py
@@ -76,6 +76,7 @@ class Scheduler:
     def swap_req_to_waiting(self, sequence: RequestSequence):
         self.free_sequence_resources(sequence)
         sequence.out_cache_loc = []
+        sequence.out_cache_loc_spec = []
         sequence.status = "WAITING"
         sequence.new_tokens = sequence.tokens.copy()
         self.waiting_queue.put(sequence)
@@ -193,10 +194,11 @@ class Scheduler:
         if sequence.sequence_id in self.abort_requests:
             self.abort_requests.remove(sequence.sequence_id)
 
-        if not len(sequence.out_cache_loc):
-            return
-        self.mem_pool.free_block(sequence.out_cache_loc)
-        self.scheduler_policy.release_req(sequence)
+        if sequence.out_cache_loc:
+            self.mem_pool.free_block(sequence.out_cache_loc)
+            self.scheduler_policy.release_req(sequence)
+        if sequence.out_cache_loc_spec:
+            self.draft_memory_pool.free_block(sequence.out_cache_loc_spec)
 
     def is_done(self) -> bool:
         return self.waiting_queue.empty() and self.running_queue.empty()

--- a/python/sfllm/kernels/dflash2.py
+++ b/python/sfllm/kernels/dflash2.py
@@ -1,0 +1,103 @@
+"""Capture-safe kernels for the DFlash2 block algorithm."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _prepare_block_kernel(
+    anchor_tokens,
+    anchor_positions,
+    block_ids,
+    positions,
+    mask_token_id,
+    block_size: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK)
+    valid = cols < block_size
+    anchor = tl.load(anchor_tokens + row)
+    position = tl.load(anchor_positions + row)
+    offset = row * block_size + cols
+    tl.store(
+        block_ids + offset,
+        tl.where(cols == 0, anchor, mask_token_id),
+        mask=valid,
+    )
+    tl.store(positions + offset, position + cols, mask=valid)
+
+
+def prepare_dflash2_block(
+    *,
+    anchor_tokens: torch.Tensor,
+    anchor_positions: torch.Tensor,
+    block_ids_out: torch.Tensor,
+    positions_out: torch.Tensor,
+    mask_token_id: int,
+) -> None:
+    batch_size, block_size = block_ids_out.shape
+    _prepare_block_kernel[(batch_size,)](
+        anchor_tokens,
+        anchor_positions,
+        block_ids_out,
+        positions_out,
+        int(mask_token_id),
+        block_size=block_size,
+        BLOCK=triton.next_power_of_2(block_size),
+        num_warps=1,
+    )
+
+
+@triton.jit
+def _selector_greedy_walk_kernel(
+    candidate_ids,
+    scores,
+    proposals_out,
+    slots: tl.constexpr,
+    top_k: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_K)
+    valid = offsets < top_k
+    predecessor = 0
+    for slot in range(slots):
+        score_offset = ((row * slots + slot) * top_k + predecessor) * top_k
+        values = tl.load(
+            scores + score_offset + offsets,
+            mask=valid,
+            other=-float("inf"),
+        )
+        best = tl.max(values, axis=0)
+        selected = tl.min(tl.where(values == best, offsets, top_k), axis=0)
+        token_offset = (row * slots + slot) * top_k + selected
+        tl.store(
+            proposals_out + row * slots + slot,
+            tl.load(candidate_ids + token_offset),
+        )
+        predecessor = selected
+
+
+def dflash2_selector_greedy_walk(
+    candidate_ids: torch.Tensor,
+    scores: torch.Tensor,
+    proposals_out: torch.Tensor,
+) -> None:
+    batch_size, slots, top_k = candidate_ids.shape
+    _selector_greedy_walk_kernel[(batch_size,)](
+        candidate_ids,
+        scores,
+        proposals_out,
+        slots=slots,
+        top_k=top_k,
+        BLOCK_K=triton.next_power_of_2(top_k),
+        num_warps=1,
+    )
+
+
+__all__ = [
+    "dflash2_selector_greedy_walk",
+    "prepare_dflash2_block",
+]

--- a/python/sfllm/layers/radix_attention.py
+++ b/python/sfllm/layers/radix_attention.py
@@ -53,6 +53,7 @@ class RadixAttention(nn.Module):
         self.logit_cap = logit_cap
         self.sliding_window_size = sliding_window_size or -1
         self.is_cross_attention = is_cross_attention
+        self.is_causal = True
         self.use_irope = use_irope
         self.k_scale = None
         self.v_scale = None

--- a/python/sfllm/layers/triton_attention.py
+++ b/python/sfllm/layers/triton_attention.py
@@ -68,7 +68,7 @@ class RaggedAttention:
             forward_batch.update(k, v, layer.layer_id)
 
         custom_mask = forward_batch.custom_mask
-        is_causal = True
+        is_causal = layer.is_causal
         mask_indptr = forward_batch.mask_indptr
         sm_scale = layer.scaling
         logit_cap=0.0

--- a/python/sfllm/models/dflash2.py
+++ b/python/sfllm/models/dflash2.py
@@ -1,0 +1,503 @@
+"""Qwen3 DFlash2 draft model.
+
+The draft owns its transformer, block-local convolutions, context projection,
+and candidate selector. Token embeddings and the vocabulary head are supplied
+by the target model at execution time.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sfllm.engine.forward_params import ForwardBatch
+from sfllm.layers.layernorm import RMSNorm
+from sfllm.model_loader.weight_utils import default_weight_loader
+from sfllm.models.qwen3 import Qwen3Attention, Qwen3MLP
+
+
+@dataclass(frozen=True)
+class DFlash2Config:
+    """The runtime fields emitted by the DFlash-to-DFlash2 initializer."""
+
+    block_size: int
+    mask_token_id: int
+    conv_kernel_size: int
+    conv_group_size: int
+    selector_rank: int
+    selector_top_k: int
+    target_layer_ids: Tuple[int, ...]
+
+    @classmethod
+    def from_hf_config(cls, config: Any) -> "DFlash2Config":
+        raw = config.to_dict() if hasattr(config, "to_dict") else dict(config)
+        if raw.get("model_type") != "qwen3":
+            raise ValueError("DFlash2 currently supports Qwen3 draft checkpoints.")
+        if bool(raw.get("attention_bias", False)):
+            raise ValueError(
+                "DFlash2 target-KV materialization currently requires "
+                "attention_bias=false."
+            )
+
+        section = raw.get("dflash_config")
+        if not isinstance(section, Mapping):
+            raise ValueError("DFlash2 checkpoint is missing dflash_config.")
+        try:
+            parsed = cls(
+                block_size=int(section["block_size"]),
+                mask_token_id=int(section["mask_token_id"]),
+                conv_kernel_size=int(section["conv_kernel_size"]),
+                conv_group_size=int(section["conv_group_size"]),
+                selector_rank=int(section["selector_rank"]),
+                selector_top_k=int(section["selector_top_k"]),
+                target_layer_ids=tuple(int(x) for x in section["target_layer_ids"]),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("Invalid canonical DFlash2 checkpoint config.") from exc
+
+        if parsed.block_size < 2:
+            raise ValueError("DFlash2 block_size must be at least two.")
+        if parsed.conv_kernel_size <= 0 or parsed.conv_group_size <= 0:
+            raise ValueError("DFlash2 convolution sizes must be positive.")
+        if parsed.selector_rank <= 0 or parsed.selector_top_k <= 0:
+            raise ValueError("DFlash2 selector rank and top-k must be positive.")
+        if int(raw["hidden_size"]) % parsed.conv_group_size:
+            raise ValueError("DFlash2 conv_group_size must divide hidden_size.")
+        if section.get("sample_from_anchor", False) is not False:
+            raise ValueError("DFlash2 currently requires sample_from_anchor=false.")
+        vocab_size = int(raw["vocab_size"])
+        if not 0 <= parsed.mask_token_id < vocab_size:
+            raise ValueError("DFlash2 mask_token_id is outside the vocabulary.")
+        if parsed.selector_top_k > vocab_size:
+            raise ValueError("DFlash2 selector_top_k exceeds the vocabulary size.")
+        if (
+            not parsed.target_layer_ids
+            or any(x < 0 for x in parsed.target_layer_ids)
+            or tuple(sorted(set(parsed.target_layer_ids))) != parsed.target_layer_ids
+        ):
+            raise ValueError(
+                "DFlash2 target_layer_ids must be non-negative, unique, and sorted."
+            )
+        num_hidden_layers = int(raw["num_hidden_layers"])
+        layer_types = raw.get("layer_types")
+        if (
+            num_hidden_layers <= 0
+            or not isinstance(layer_types, list)
+            or len(layer_types) != num_hidden_layers
+        ):
+            raise ValueError("DFlash2 requires one layer_types entry per draft layer.")
+        if any(layer_type != "full_attention" for layer_type in layer_types):
+            raise ValueError(
+                "The Qwen3 DFlash2 backend currently supports "
+                "full-attention drafts only."
+            )
+        return parsed
+
+
+class DFlash2Attention(Qwen3Attention):
+    """Non-causal Qwen3 block attention with target-KV materialization."""
+
+    def __init__(self, config, layer_id: int, quant_config=None, prefix: str = ""):
+        super().__init__(
+            hidden_size=int(config.hidden_size),
+            num_heads=int(config.num_attention_heads),
+            num_kv_heads=int(config.num_key_value_heads),
+            layer_id=layer_id,
+            rope_theta=float(getattr(config, "rope_theta", 1_000_000)),
+            rope_scaling=getattr(config, "rope_scaling", None),
+            head_dim=int(getattr(config, "head_dim", 0) or 0) or None,
+            max_position_embeddings=int(config.max_position_embeddings),
+            quant_config=quant_config,
+            rms_norm_eps=float(config.rms_norm_eps),
+            attention_bias=bool(config.attention_bias),
+            prefix=prefix,
+            alt_stream=None,
+        )
+        self.attn.is_causal = False
+
+    def materialize_kv(
+        self,
+        raw_kv: torch.Tensor,
+        positions: torch.Tensor,
+        cache_locs: torch.Tensor,
+        kv_buffer: Tuple[torch.Tensor, torch.Tensor],
+    ) -> None:
+        k, v = raw_kv.split([self.kv_size, self.kv_size], dim=-1)
+        k = self.k_norm(k.reshape(-1, self.head_dim)).view_as(k)
+        # The CUDA RoPE op also performs the pool write. This avoids a second
+        # indexed scatter for every draft layer inside the decode graph.
+        dummy_q = torch.empty_like(k)
+        self.rotary_emb(
+            positions,
+            dummy_q,
+            k,
+            fused_set_kv_buffer_arg=(v, kv_buffer[0], kv_buffer[1], cache_locs),
+        )
+
+
+@torch.compile(dynamic=True)
+def _grouped_conv(
+    hidden_states: torch.Tensor,
+    delta: torch.Tensor,
+    base: torch.Tensor,
+    block_size: int,
+    num_groups: int,
+    group_size: int,
+    taps: int,
+) -> torch.Tensor:
+    blocks = hidden_states.unflatten(-1, (num_groups, group_size))
+    coefficients = base.view(1, taps, num_groups, group_size) + delta.unsqueeze(-1)
+    output = coefficients[:, 0] * blocks
+    positions = torch.arange(hidden_states.shape[0], device=hidden_states.device)
+    if block_size & (block_size - 1) == 0:
+        positions = positions & (block_size - 1)
+    else:
+        positions = positions % block_size
+    for tap in range(1, taps):
+        shifted = F.pad(blocks[:-tap], (0, 0, 0, 0, tap, 0))
+        output = output + coefficients[:, tap] * shifted * (
+            positions >= tap
+        ).view(-1, 1, 1)
+    return output.flatten(-2)
+
+
+class DFlash2GroupedConv(nn.Module):
+    """Block-local dynamic depthwise convolution used by DFlash2."""
+
+    def __init__(
+        self, hidden_size: int, block_size: int, taps: int, group_size: int
+    ) -> None:
+        super().__init__()
+        self.block_size = int(block_size)
+        self.taps = int(taps)
+        self.group_size = int(group_size)
+        self.num_groups = int(hidden_size) // self.group_size
+
+        base_kernel = torch.zeros(2, self.taps, int(hidden_size))
+        base_kernel[:, 0] = 1
+        self.base_kernel = nn.Parameter(base_kernel)
+        self.kernel_projection = nn.Linear(
+            int(hidden_size), 2 * self.taps * self.num_groups, bias=False
+        )
+
+    def _convolve(
+        self, hidden_states: torch.Tensor, coefficients: torch.Tensor, side: int
+    ) -> torch.Tensor:
+        return _grouped_conv(
+            hidden_states,
+            coefficients,
+            self.base_kernel[side],
+            self.block_size,
+            self.num_groups,
+            self.group_size,
+            self.taps,
+        )
+
+    def prepare(self, hidden_states: torch.Tensor):
+        coefficients = self.kernel_projection(hidden_states).reshape(
+            *hidden_states.shape[:-1], 2, self.taps, self.num_groups
+        )
+        return (
+            self._convolve(hidden_states, coefficients[..., 0, :, :], side=0),
+            coefficients[..., 1, :, :],
+        )
+
+    def finish(
+        self, hidden_states: torch.Tensor, coefficients: torch.Tensor
+    ) -> torch.Tensor:
+        return self._convolve(hidden_states, coefficients, side=1)
+
+
+class DFlash2DecoderLayer(nn.Module):
+    def __init__(self, config, layer_id: int, quant_config=None) -> None:
+        super().__init__()
+        hidden_size = int(config.hidden_size)
+        self.input_layernorm = RMSNorm(hidden_size, eps=float(config.rms_norm_eps))
+        self.self_attn = DFlash2Attention(
+            config,
+            layer_id,
+            quant_config=quant_config,
+            prefix=f"layers.{layer_id}.self_attn",
+        )
+        self.post_attention_layernorm = RMSNorm(
+            hidden_size, eps=float(config.rms_norm_eps)
+        )
+        self.mlp = Qwen3MLP(
+            hidden_size=hidden_size,
+            intermediate_size=int(config.intermediate_size),
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=f"layers.{layer_id}.mlp",
+        )
+        conv_args = (
+            hidden_size,
+            int(config.dflash_config["block_size"]),
+            int(config.dflash_config["conv_kernel_size"]),
+            int(config.dflash_config["conv_group_size"]),
+        )
+        self.attention_conv = DFlash2GroupedConv(*conv_args)
+        self.mlp_conv = DFlash2GroupedConv(*conv_args)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        hidden_states, attention_kernel = self.attention_conv.prepare(hidden_states)
+        hidden_states = self.self_attn(positions, hidden_states, forward_batch)
+        hidden_states = self.attention_conv.finish(hidden_states, attention_kernel)
+
+        hidden_states, residual = self.post_attention_layernorm(
+            hidden_states, residual
+        )
+        hidden_states, mlp_kernel = self.mlp_conv.prepare(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp_conv.finish(hidden_states, mlp_kernel)
+        return hidden_states, residual
+
+
+class DFlash2CandidateSelector(nn.Module):
+    def __init__(
+        self, hidden_size: int, vocab_size: int, state_rank: int, top_k: int
+    ) -> None:
+        super().__init__()
+        self.top_k = int(top_k)
+        self.predecessor_codebook = nn.Parameter(
+            torch.zeros(vocab_size, state_rank), requires_grad=False
+        )
+        self.successor_codebook = nn.Parameter(
+            torch.zeros(vocab_size, state_rank), requires_grad=False
+        )
+        self.hidden_projection = nn.Linear(hidden_size, state_rank, bias=False)
+
+    def build_lattice(
+        self,
+        candidate_ids: torch.Tensor,
+        unary_logits: torch.Tensor,
+        hidden_states: torch.Tensor,
+        anchor_token_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden = self.hidden_projection(hidden_states)
+        successors = self.successor_codebook[candidate_ids]
+        predecessor_ids = torch.cat(
+            (
+                anchor_token_ids[:, None, None].expand(-1, 1, self.top_k),
+                candidate_ids[:, :-1],
+            ),
+            dim=1,
+        )
+        predecessors = self.predecessor_codebook[predecessor_ids]
+        pairwise = torch.einsum(
+            "blpr,blcr->blpc", predecessors * hidden[:, :, None], successors
+        )
+        return unary_logits[:, :, None, :] + pairwise.float()
+
+
+class DFlash2DraftModel(nn.Module):
+    """Qwen3 DFlash2 backbone and low-rank path selector."""
+
+    def __init__(self, config, quant_config=None, prefix: str = "") -> None:
+        super().__init__()
+        del prefix
+        self.config = config
+        self.dflash_config = DFlash2Config.from_hf_config(config)
+        hidden_size = int(config.hidden_size)
+        self.layers = nn.ModuleList(
+            [
+                DFlash2DecoderLayer(config, layer_id, quant_config=quant_config)
+                for layer_id in range(int(config.num_hidden_layers))
+            ]
+        )
+        self.norm = RMSNorm(hidden_size, eps=float(config.rms_norm_eps))
+        self.fc = nn.Linear(
+            len(self.dflash_config.target_layer_ids) * hidden_size,
+            hidden_size,
+            bias=False,
+        )
+        self.speculative_hidden_size = self.fc.out_features
+        self.hidden_norm = RMSNorm(hidden_size, eps=float(config.rms_norm_eps))
+        self.candidate_selector = DFlash2CandidateSelector(
+            hidden_size,
+            int(config.vocab_size),
+            self.dflash_config.selector_rank,
+            self.dflash_config.selector_top_k,
+        )
+        self.register_buffer("_flat_kv_weight_t", None, persistent=False)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        del input_ids
+        if input_embeds is None:
+            raise ValueError("DFlash2 must receive embeddings from the target model.")
+        hidden_states = input_embeds
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions, hidden_states, forward_batch, residual
+            )
+        if residual is None:
+            return self.norm(hidden_states)
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    def compute_candidates(
+        self, hidden_states: torch.Tensor, target_head_weight: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        logits = torch.matmul(
+            hidden_states.to(target_head_weight.dtype), target_head_weight.T
+        )
+        values, ids = torch.topk(
+            logits, self.dflash_config.selector_top_k, dim=-1, sorted=True
+        )
+        return ids.to(torch.int64), values.float()
+
+    def project_target_hidden(self, target_hidden: torch.Tensor) -> torch.Tensor:
+        if target_hidden.ndim != 2 or target_hidden.shape[1] != self.fc.in_features:
+            raise ValueError(
+                "DFlash2 target hidden feature mismatch: expected [N, "
+                f"{self.fc.in_features}], got {tuple(target_hidden.shape)}."
+            )
+        return self.hidden_norm(self.fc(target_hidden))
+
+    def _finalize_kv_projection(self) -> None:
+        kv_weights = []
+        for layer in self.layers:
+            attention = layer.self_attn
+            weight = attention.qkv_proj.weight
+            kv_weights.append(
+                weight[attention.q_size : attention.q_size + 2 * attention.kv_size]
+            )
+        stacked = torch.stack(kv_weights).reshape(-1, int(self.config.hidden_size))
+        self._flat_kv_weight_t = stacked.T.contiguous()
+
+    def materialize_target_kv(
+        self,
+        target_hidden: torch.Tensor,
+        positions: torch.Tensor,
+        cache_locs: torch.Tensor,
+        kv_buffers,
+    ) -> None:
+        self.materialize_context_kv(
+            self.project_target_hidden(target_hidden),
+            positions,
+            cache_locs,
+            kv_buffers,
+        )
+
+    def materialize_context_kv(
+        self,
+        context: torch.Tensor,
+        positions: torch.Tensor,
+        cache_locs: torch.Tensor,
+        kv_buffers,
+    ) -> None:
+        if self._flat_kv_weight_t is None:
+            raise RuntimeError("DFlash2 KV projection was not finalized after loading.")
+        if context.ndim != 2 or context.shape[1] != int(self.config.hidden_size):
+            raise ValueError(
+                "DFlash2 projected context must have shape [N, hidden_size]."
+            )
+        raw_kv = torch.matmul(context, self._flat_kv_weight_t)
+        raw_kv = raw_kv.view(
+            context.shape[0], len(self.layers), 2 * self.layers[0].self_attn.kv_size
+        )
+        for layer_id, layer in enumerate(self.layers):
+            layer.self_attn.materialize_kv(
+                raw_kv[:, layer_id], positions, cache_locs, kv_buffers[layer_id]
+            )
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> None:
+        stacked_params = (
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        )
+        ignored = {"embed_tokens.weight", "lm_head.weight"}
+        params = dict(self.named_parameters())
+        loaded_directly = set()
+        loaded_shards = defaultdict(set)
+        required_shards = {
+            "qkv_proj": {"q", "k", "v"},
+            "gate_up_proj": {0, 1},
+        }
+
+        for name, loaded_weight in weights:
+            if name.startswith("model."):
+                name = name[len("model.") :]
+            if name in ignored:
+                continue
+            for packed_name, checkpoint_name, shard_id in stacked_params:
+                if f".{checkpoint_name}." not in f".{name}":
+                    continue
+                mapped_name = name.replace(checkpoint_name, packed_name)
+                if mapped_name not in params:
+                    raise KeyError(f"Unexpected DFlash2 weight {name!r}.")
+                if mapped_name in loaded_directly:
+                    raise RuntimeError(
+                        f"DFlash2 parameter {mapped_name!r} is present both fused "
+                        "and as separate checkpoint shards."
+                    )
+                if shard_id in loaded_shards[mapped_name]:
+                    raise RuntimeError(
+                        f"Duplicate DFlash2 shard {shard_id!r} for {mapped_name!r}."
+                    )
+                parameter = params[mapped_name]
+                loader = getattr(parameter, "weight_loader", default_weight_loader)
+                loader(parameter, loaded_weight, shard_id)
+                loaded_shards[mapped_name].add(shard_id)
+                break
+            else:
+                if name not in params:
+                    raise KeyError(f"Unexpected DFlash2 weight {name!r}.")
+                if name in loaded_directly or name in loaded_shards:
+                    raise RuntimeError(f"Duplicate DFlash2 parameter {name!r}.")
+                parameter = params[name]
+                loader = getattr(parameter, "weight_loader", default_weight_loader)
+                loader(parameter, loaded_weight)
+                loaded_directly.add(name)
+
+        incomplete = []
+        for name, shards in loaded_shards.items():
+            packed_name = next(
+                packed for packed in required_shards if f".{packed}." in f".{name}"
+            )
+            expected = required_shards[packed_name]
+            if shards != expected:
+                incomplete.append(
+                    f"{name}: missing={sorted(expected - shards, key=str)}, "
+                    f"loaded={sorted(shards, key=str)}"
+                )
+        if incomplete:
+            raise RuntimeError(
+                "DFlash2 checkpoint has incomplete packed parameters: "
+                + "; ".join(sorted(incomplete))
+            )
+
+        loaded = loaded_directly | set(loaded_shards)
+        missing = sorted(set(params) - loaded)
+        if missing:
+            raise RuntimeError(f"DFlash2 checkpoint is missing weights: {missing}.")
+        self._finalize_kv_projection()
+
+
+EntryClass = DFlash2DraftModel

--- a/python/sfllm/models/llama_eagle3.py
+++ b/python/sfllm/models/llama_eagle3.py
@@ -189,6 +189,7 @@ class LlamaForCausalLMEagle3(LlamaForCausalLM):
         self.model = LlamaModel(
             config, quant_config=quant_config, prefix=add_prefix("model", prefix)
         )
+        self.speculative_hidden_size = self.model.fc.in_features
         # Llama 3.2 1B Instruct set tie_word_embeddings to True
         # Llama 3.1 8B Instruct set tie_word_embeddings to False
         self.load_lm_head_from_target = False

--- a/python/sfllm/server_args.py
+++ b/python/sfllm/server_args.py
@@ -133,7 +133,7 @@ class ServerArgs:
             "--speculative-algorithm",
             type=str.lower,
             default=ServerArgs.speculative_algorithm,
-            choices=[None, "eagle3"],
+            choices=[None, "eagle3", "dflash2"],
             help="The speculative decoding algorithm to use.",
         )
         parser.add_argument(

--- a/python/sfllm/spec_decoding/dflash2_worker.py
+++ b/python/sfllm/spec_decoding/dflash2_worker.py
@@ -1,0 +1,287 @@
+"""DFlash2 proposal logic on SFLLM's shared speculative protocol."""
+
+import torch
+from transformers import PretrainedConfig
+
+from sfllm.engine.forward_params import ForwardBatch, ForwardMode
+from sfllm.engine.schedule_batch import BatchResult, ScheduleBatch
+from sfllm.kernels.dflash2 import (
+    dflash2_selector_greedy_walk,
+    prepare_dflash2_block,
+)
+from sfllm.models.dflash2 import DFlash2Config
+from sfllm.server_args import ServerArgs
+from sfllm.spec_decoding.spec_utils import EagleSpecInput, EagleVerifyInput
+from sfllm.spec_decoding.spec_worker import SpeculativeWorker
+
+
+def _validate_model_pair(
+    draft_config,
+    target_config,
+    dflash2_config: DFlash2Config,
+) -> None:
+    if getattr(target_config, "model_type", None) != "qwen3":
+        raise ValueError("DFlash2 currently supports Qwen3 targets.")
+    for name in ("hidden_size", "vocab_size"):
+        draft_value = getattr(draft_config, name, None)
+        target_value = getattr(target_config, name, None)
+        if draft_value != target_value:
+            raise ValueError(
+                "DFlash2 draft/target shape mismatch: "
+                f"draft {name}={draft_value!r}, target {name}={target_value!r}."
+            )
+
+    target_num_layers = int(getattr(target_config, "num_hidden_layers", 0) or 0)
+    invalid_layer_ids = [
+        layer_id
+        for layer_id in dflash2_config.target_layer_ids
+        if layer_id >= target_num_layers
+    ]
+    if invalid_layer_ids:
+        raise ValueError(
+            "DFlash2 target_layer_ids are outside the target model: "
+            f"{invalid_layer_ids}."
+        )
+
+
+class DFlash2Worker(SpeculativeWorker):
+    """DFlash2 model logic on top of SFLLM's Eagle overlap contract."""
+
+    def __init__(self, server_args: ServerArgs) -> None:
+        if not server_args.speculative_draft_model_path:
+            raise ValueError("DFlash2 requires --speculative-draft-model-path.")
+        if server_args.quantization is not None:
+            raise ValueError(
+                "The initial DFlash2 backend supports dense target/draft weights only."
+            )
+
+        draft_config_dict, _ = PretrainedConfig.get_config_dict(
+            server_args.speculative_draft_model_path
+        )
+        checkpoint_config = DFlash2Config.from_hf_config(draft_config_dict)
+
+        # A DFlash block maps directly to the shared Eagle protocol width.
+        server_args.speculative_eagle_topk = 1
+        server_args.speculative_num_steps = checkpoint_config.block_size - 1
+        server_args.speculative_num_draft_tokens = checkpoint_config.block_size
+        self.block_size = checkpoint_config.block_size
+
+        super().__init__(server_args)
+        self.dflash2_config = self.draft_model_runner.model.dflash_config
+        _validate_model_pair(
+            draft_config=self.draft_model_runner.get_config(),
+            target_config=self.target_model_runner.get_config(),
+            dflash2_config=self.dflash2_config,
+        )
+
+        target_model = self.target_model_runner.model
+        target_model.set_eagle3_layers_to_capture(
+            list(self.dflash2_config.target_layer_ids)
+        )
+
+        self._profile_models()
+        self.init_memory_pools()
+
+        self._allocate_decode_buffers()
+        self.init_e2e_runner(self.forward_decode_e2e)
+
+    @torch.inference_mode()
+    def _profile_models(self) -> None:
+        self.target_model_runner.profile_run()
+        token_count = self.block_size * min(8, int(self.server_args.cuda_graph_max_bs))
+        input_ids = torch.zeros(token_count, dtype=torch.int64, device="cuda")
+        positions = torch.arange(token_count, dtype=torch.int64, device="cuda")
+        embeddings = self.target_model_runner.model.get_input_embeddings()(input_ids)
+        draft_batch = ForwardBatch(None)
+        draft_batch.forward_mode = ForwardMode.DRAFT_EXTEND
+        self.draft_model_runner.model(
+            input_ids=input_ids,
+            positions=positions,
+            forward_batch=draft_batch,
+            input_embeds=embeddings,
+        )
+
+    def _allocate_decode_buffers(self) -> None:
+        max_bs = int(self.server_args.cuda_graph_max_bs)
+        block = self.block_size
+        protocol_width = self.draft_model_runner.hidden_states_buffer.shape[-1]
+        device = torch.device("cuda", int(self.target_model_runner.device_id))
+
+        scratch_count = max_bs * block
+        assert self.draft_mem_pool.can_alloc(scratch_count)
+        self._draft_scratch_locs = torch.tensor(
+            self.draft_mem_pool.persist_alloc_block_from_rear(scratch_count),
+            dtype=torch.int64,
+            device=device,
+        )
+        self._block_ids = torch.empty((max_bs, block), dtype=torch.int64, device=device)
+        self._positions = torch.empty_like(self._block_ids)
+        self._proposals = torch.empty(
+            (max_bs, block - 1), dtype=torch.int64, device=device
+        )
+        self._candidates = torch.empty_like(self._block_ids)
+        self._protocol_hidden = torch.empty(
+            (max_bs * block, protocol_width), dtype=self.dtype, device=device
+        )
+        token_indices = torch.arange(block, dtype=torch.int64, device=device)
+        self._retrieve_index = (
+            token_indices[None]
+            + torch.arange(max_bs, dtype=torch.int64, device=device)[:, None] * block
+        )
+        self._retrieve_next_token = token_indices.add(1).repeat(max_bs, 1)
+        self._retrieve_next_token[:, -1] = -1
+        self._retrieve_next_sibling = torch.full_like(self._retrieve_index, -1)
+
+    @torch.inference_mode()
+    def forward(self, batch: ScheduleBatch) -> BatchResult:
+        if batch.forward_batch.forward_mode == ForwardMode.EXTEND:
+            return self._forward_prefill(batch)
+        return self.forward_e2e(batch)
+
+    @torch.inference_mode()
+    def _forward_prefill(self, batch: ScheduleBatch) -> BatchResult:
+        if not all(sequence.sampling_params.is_greedy for sequence in batch):
+            raise ValueError("DFlash2 currently supports greedy requests only.")
+
+        output = self.target_model_runner.forward(batch)
+        if output.aux_hidden_states is None:
+            raise RuntimeError("DFlash2 target prefill returned no captured states.")
+        self.draft_model_runner.model.materialize_target_kv(
+            target_hidden=torch.cat(output.aux_hidden_states, dim=-1),
+            positions=batch.position_ids,
+            cache_locs=batch.forward_batch_spec.out_cache_loc,
+            kv_buffers=self.draft_mem_pool.kv_buffers,
+        )
+
+        spec_info = EagleSpecInput(
+            accept_length=torch.full(
+                (len(batch),),
+                -1,
+                dtype=torch.int32,
+                device=output.next_token_ids.device,
+            ),
+            verified_id=output.next_token_ids,
+            hidden_states=torch.zeros(
+                (
+                    len(batch) * self.block_size,
+                    self.draft_model_runner.hidden_states_buffer.shape[1],
+                ),
+                dtype=self.dtype,
+                device=output.next_token_ids.device,
+            ),
+        )
+        spec_info.hash = batch.get_seq_groups_hash()
+        batch.spec_info = spec_info
+        batch.forward_batch_spec.spec_info = spec_info
+        output.spec_info = spec_info
+        output.aux_hidden_states = None
+        return output
+
+    def _draft_block_batch(self, batch: ScheduleBatch) -> ForwardBatch:
+        batch_size = len(batch)
+        token_count = batch_size * self.block_size
+        forward_batch = ForwardBatch(self.draft_mem_pool)
+        forward_batch.forward_mode = ForwardMode.DRAFT_EXTEND
+        forward_batch.qo_indptr = batch.forward_batch.qo_indptr
+        forward_batch.kv_indptr = batch.forward_batch_spec.kv_indptr
+        forward_batch.kv_indices = batch.forward_batch_spec.kv_indices
+        forward_batch.out_cache_loc = self._draft_scratch_locs[:token_count]
+        forward_batch.seq_lens = batch.forward_batch.seq_lens
+        forward_batch.max_extend_len = self.block_size
+        return forward_batch
+
+    def commit_previous(self, batch: ScheduleBatch) -> None:
+        """Advance DFlash2's draft KV state with the previous accepted context."""
+        spec_info = batch.spec_info
+        cache_locs = batch.forward_batch_spec.out_cache_loc
+        count = cache_locs.shape[0]
+        valid_count = torch.clamp(spec_info.accept_length + 1, min=0).sum()
+        valid = torch.arange(count, device=cache_locs.device) < valid_count
+        safe_cache_locs = torch.where(
+            valid,
+            cache_locs,
+            self._draft_scratch_locs[:count],
+        )
+        hidden_size = int(self.config.hidden_size)
+        self.draft_model_runner.model.materialize_context_kv(
+            context=spec_info.hidden_states[:count, :hidden_size],
+            positions=batch.forward_batch_spec.position_ids_extend[:count],
+            cache_locs=safe_cache_locs,
+            kv_buffers=self.draft_mem_pool.kv_buffers,
+        )
+
+    def proposal(self, batch: ScheduleBatch) -> EagleVerifyInput:
+        """Build one linear DFlash2 proposal block."""
+        batch_size = len(batch)
+        block = self.block_size
+        spec_info = batch.spec_info
+
+        anchor_indices = batch.forward_batch_spec.qo_indptr[1:] - 1
+        prepare_dflash2_block(
+            anchor_tokens=spec_info.verified_id[anchor_indices],
+            anchor_positions=batch.position_ids,
+            block_ids_out=self._block_ids[:batch_size],
+            positions_out=self._positions[:batch_size],
+            mask_token_id=self.dflash2_config.mask_token_id,
+        )
+
+        flat_ids = self._block_ids[:batch_size].reshape(-1)
+        flat_positions = self._positions[:batch_size].reshape(-1)
+        embeddings = self.target_model_runner.model.get_input_embeddings()(flat_ids)
+        draft_hidden = self.draft_model_runner.model(
+            input_ids=flat_ids,
+            positions=flat_positions,
+            forward_batch=self._draft_block_batch(batch),
+            input_embeds=embeddings,
+        ).view(batch_size, block, -1)
+
+        prediction_hidden = draft_hidden[:, 1:]
+        candidate_ids, unary_logits = self.draft_model_runner.model.compute_candidates(
+            prediction_hidden.reshape(-1, prediction_hidden.shape[-1]),
+            self.target_model_runner.model.lm_head.weight,
+        )
+        top_k = self.dflash2_config.selector_top_k
+        candidate_ids = candidate_ids.view(batch_size, block - 1, top_k)
+        selector_scores = (
+            self.draft_model_runner.model.candidate_selector.build_lattice(
+                candidate_ids=candidate_ids,
+                unary_logits=unary_logits.view(batch_size, block - 1, top_k),
+                hidden_states=prediction_hidden,
+                anchor_token_ids=self._block_ids[:batch_size, 0],
+            )
+        )
+        dflash2_selector_greedy_walk(
+            candidate_ids, selector_scores, self._proposals[:batch_size]
+        )
+
+        candidates = self._candidates[:batch_size]
+        candidates[:, 0].copy_(self._block_ids[:batch_size, 0])
+        candidates[:, 1:].copy_(self._proposals[:batch_size])
+        return EagleVerifyInput(
+            draft_token=candidates.reshape(-1),
+            custom_mask=None,
+            positions=flat_positions,
+            retrive_index=self._retrieve_index[:batch_size],
+            retrive_next_token=self._retrieve_next_token[:batch_size],
+            retrive_next_sibling=self._retrieve_next_sibling[:batch_size],
+            retrive_cum_len=None,
+            spec_steps=block - 1,
+            topk=1,
+            draft_token_num=block,
+        )
+
+    def _adapt_verified_hidden_states(
+        self, batch: ScheduleBatch, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        """Project target states into DFlash2's next-step context."""
+        token_count = len(batch) * self.block_size
+        target_context = self.draft_model_runner.model.project_target_hidden(
+            hidden_states
+        )
+        protocol_hidden = self._protocol_hidden[:token_count]
+        protocol_hidden.zero_()
+        protocol_hidden[:, : target_context.shape[1]].copy_(target_context)
+        return protocol_hidden
+
+
+__all__ = ["DFlash2Worker"]

--- a/python/sfllm/spec_decoding/eagle_worker.py
+++ b/python/sfllm/spec_decoding/eagle_worker.py
@@ -6,7 +6,6 @@ from typing import List
 from sfllm.engine.schedule_batch import ScheduleBatch,BatchResult
 from sfllm.engine.forward_params import ForwardMode, ForwardBatch
 from sfllm.server_args import ServerArgs
-from sfllm.engine.model_runner import ModelRunner
 from sfllm.spec_decoding.spec_utils import (EagleSpecInput,
                                             EagleVerifyInput,
                                             select_top_k_tokens,
@@ -15,33 +14,20 @@ from sfllm.spec_decoding.spec_utils import (EagleSpecInput,
                                             build_tree_kernel_efficient,
                                             generate_kv_indices_for_mtd)
 from sfllm.spec_decoding.draft_cuda_graph_runner import EagleCudaGraphRunner
-from sfllm.spec_decoding.eagle3_e2e_cuda_graph_runner import EagleE2ECudaGraphRunner
-import transformers
+from sfllm.spec_decoding.spec_worker import SpeculativeWorker
 
 ALIGN_EAGLE_WITH_SGLANG_ = False
 logger = logging.getLogger(__name__)
 
 for_comparation = None
-class EagleWorker:
+class EagleWorker(SpeculativeWorker):
     def __init__(self,server_args:ServerArgs):
-        self.draft_model_runner = ModelRunner(server_args, is_draft=True)
-        self.target_model_runner = ModelRunner(server_args)
+        super().__init__(server_args)
         self.target_model_runner.model.set_eagle3_layers_to_capture()
-        self.server_args = server_args
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
-        server_args.model_config = self.target_model_runner.model.config
-        self.tokenizer = transformers.AutoTokenizer.from_pretrained(server_args.model_path)
-        self.draft_model_runner.wrap_target_model(self.target_model_runner)
-        self.detokenize = self.target_model_runner.detokenize
-        self.compute_stream = self.target_model_runner.compute_stream
-        self.dtype = self.target_model_runner.dtype
-        self.config = self.target_model_runner.model.config
 
-        #statistics
-        self.total_accepted_tokens = 0
-        
         #eagle3 draft model share embedding with target model
         embed, head = self.target_model_runner.model.get_embed_and_head()
         if (
@@ -54,12 +40,10 @@ class EagleWorker:
 
         #======init
         self.profile_run()
-        self.target_model_runner.init_memory_pool()
-        self.draft_model_runner.init_memory_pool(num_blocks=self.target_model_runner.block_memory_manager.num_blocks)
+        self.init_memory_pools()
         
         self.draft_decode_forward_runner = EagleCudaGraphRunner(self.draft_model_runner, self.draft_decode_forward)
-        self.eagle_e2e_runner = EagleE2ECudaGraphRunner(self.draft_model_runner, self.target_model_runner, 
-                                                                   self.forward_decode_e2e)
+        self.init_e2e_runner(self.forward_decode_e2e)
 
         self.hot_token_id = self.draft_model_runner.model.hot_token_id.to("cuda")
         self.attn_metadatas = []
@@ -80,29 +64,16 @@ class EagleWorker:
     def profile_run(self):
         forward_batch = ForwardBatch(None)
         forward_batch.spec_info = EagleSpecInput()
-        hs = self.draft_model_runner.model.config.hidden_size
+        hs = self.draft_model_runner.model.speculative_hidden_size
         dtype = self.draft_model_runner.dtype
-        hidden_states = torch.empty((64, hs*3), dtype=dtype, device="cuda")
+        profile_tokens = min(64, self.draft_model_runner.input_ids.shape[0])
+        hidden_states = torch.empty(
+            (profile_tokens, hs), dtype=dtype, device="cuda"
+        )
         forward_batch.spec_info.hidden_states = hidden_states
         self.draft_model_runner.profile_run(forward_batch)
         self.target_model_runner.profile_run()
     
-    @property
-    def main_mem_pool(self):
-        return self.target_model_runner.block_memory_manager
-
-    @property
-    def draft_mem_pool(self):
-        return self.draft_model_runner.block_memory_manager
-
-    def init_capture_cudagraph(self):
-        if not self.server_args.disable_cuda_graph:
-            self.eagle_e2e_runner.init_cuda_graph()
-            # self.target_model_runner.init_capture_cudagraph(forward_mode=ForwardMode.TARGET_VERIFY)
-            # self.draft_model_runner.init_capture_cudagraph(forward_mode=ForwardMode.DRAFT_EXTEND)
-            # self.draft_decode_forward_runner.init_cuda_graph()
-            pass
-        
     @torch.inference_mode()
     def forward(self, scheduled_batch:ScheduleBatch):
         # Implement the forward pass logic here
@@ -124,7 +95,7 @@ class EagleWorker:
             if scheduled_batch.spec_info.hidden_states.shape[-1] > self.target_model_runner.get_config().hidden_size:
                 # forward_decode_e2e
                 global for_comparation
-                for_comparation = self.eagle_e2e_runner.forward(scheduled_batch)
+                for_comparation = self.e2e_runner.forward(scheduled_batch)
                 out_args = for_comparation
             elif scheduled_batch.spec_info.hidden_states.shape[-1] == self.target_model_runner.get_config().hidden_size:
                 with torch.cuda.nvtx.range("eagle_spec_decode"):
@@ -258,7 +229,7 @@ class EagleWorker:
         return parent_list, top_scores_index, draft_tokens
 
     def draft_propose(self, scheduled_batch:ScheduleBatch):
-        self.pre_forward_last_verify_token(scheduled_batch)
+        self.commit_previous(scheduled_batch)
         spec_info = scheduled_batch.spec_info
         spec_info.verified_id = scheduled_batch.input_ids# TODO,only works for bs=1
 
@@ -313,7 +284,8 @@ class EagleWorker:
             draft_token_num=self.server_args.speculative_num_draft_tokens,
         )
 
-    def pre_forward_last_verify_token(self, scheduled_batch:ScheduleBatch):
+    def commit_previous(self, scheduled_batch: ScheduleBatch) -> None:
+        """Advance Eagle's draft KV state with the previous accepted tokens."""
         #decode for the latest token#######################
         # the first time will be skipped as we have run it in prefill stage
         spec_info = scheduled_batch.spec_info
@@ -329,7 +301,7 @@ class EagleWorker:
         forward_batch_spec.spec_info = spec_info
 
         # Run forward
-        with torch.cuda.nvtx.range("pre_forward_last_verify_token"):
+        with torch.cuda.nvtx.range("commit_previous"):
             with scheduled_batch.switch_spec_forward_batch():
                 logits_output = self.draft_model_runner.forward(scheduled_batch)
 
@@ -339,24 +311,8 @@ class EagleWorker:
         scheduled_batch.input_ids = old_input_ids
 
 
-    def verify_propose(self, scheduled_batch:ScheduleBatch, verify_input:EagleVerifyInput):
-        scheduled_batch.position_ids = verify_input.positions
-        scheduled_batch.input_ids = verify_input.draft_token
-        forward_batch = scheduled_batch.forward_batch
-
-        forward_batch.forward_mode = ForwardMode.TARGET_VERIFY
-        forward_batch.custom_mask = verify_input.custom_mask
-
-        with torch.cuda.nvtx.range("target_model_runner_forward"):
-            logits_output = self.target_model_runner.forward(scheduled_batch)
-        forward_batch.forward_mode = ForwardMode.DECODE
-        verify_input.hidden_states = torch.cat(logits_output.aux_hidden_states, dim=-1)
-
-        accept_index, accept_length, predict = verify_input.verify(scheduled_batch, logits_output, 1)
-        return verify_input, logits_output.next_token_logits, accept_index, accept_length, predict
-
     # why this work???
-    def forward_decode_e2e(self, scheduled_batch:ScheduleBatch):
+    def proposal(self, scheduled_batch:ScheduleBatch) -> EagleVerifyInput:
         #enmulate input tensors
         """
         scheduled_batch.forward_batch_spec as forward_batch:
@@ -373,26 +329,6 @@ class EagleWorker:
             scheduled_batch.input_ids = input_ids
             scheduled_batch.position_ids = position_ids
         """
-        #decode for the latest token#######################begin#######
-        spec_info = scheduled_batch.spec_info
-        forward_batch_spec = scheduled_batch.forward_batch_spec
-        old_input_ids = scheduled_batch.input_ids
-        old_position_ids = scheduled_batch.position_ids
-
-        forward_batch_spec.forward_mode = ForwardMode.DRAFT_EXTEND
-        scheduled_batch.input_ids = spec_info.verified_id
-        scheduled_batch.position_ids = scheduled_batch.forward_batch_spec.position_ids_extend
-        forward_batch_spec.spec_info = spec_info
-        # Run forward
-        with scheduled_batch.switch_spec_forward_batch():
-            logits_output = self.draft_model_runner.forward(scheduled_batch)
-        spec_info.hidden_states = logits_output.aux_hidden_states[0][(forward_batch_spec.qo_indptr[1:]-1)]
-        spec_info.logits = logits_output.next_token_logits
-        scheduled_batch.position_ids = old_position_ids
-        scheduled_batch.input_ids = old_input_ids
-
-        #########end###########################################
-
         ##### draft propose begin ##################
         spec_info = scheduled_batch.spec_info
         # spec_info.verified_id = scheduled_batch.input_ids #TODO!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -512,123 +448,4 @@ class EagleWorker:
             draft_token_num=self.server_args.speculative_num_draft_tokens,
         )
         ##### draft propose end ##################
-
-        scheduled_batch.position_ids = verify_input.positions
-        scheduled_batch.input_ids = verify_input.draft_token
-        forward_batch = scheduled_batch.forward_batch
-
-        forward_batch.forward_mode = ForwardMode.TARGET_VERIFY
-        forward_batch.custom_mask = verify_input.custom_mask
-
-        logits_output = self.target_model_runner.forward(scheduled_batch)
-        forward_batch.forward_mode = ForwardMode.DECODE
-
-        verify_input.hidden_states = torch.cat(logits_output.aux_hidden_states, dim=-1)
-
-        accept_index, accept_length, predict = verify_input.verify(scheduled_batch, logits_output, 1)
-        return verify_input, logits_output.next_token_logits, accept_index, accept_length, predict
-
-        ##===========post cuda graph================
-    def forward_decode_e2e_post_process(self, scheduled_batch:ScheduleBatch, verify_input:EagleVerifyInput, 
-                                        next_token_logits:torch.Tensor, accept_index:torch.Tensor, 
-                                        accept_length:torch.Tensor, predict:torch.Tensor):
-        logits_output = BatchResult(None, next_token_logits, None)
-        ret = verify_input.verify_post_process(scheduled_batch, accept_index, accept_length, predict)
-        logits_output.next_token_ids = ret.verified_id # padded for async
-        # logits_output.next_token_logits = logits_output.next_token_logits[ret.accepted_indices] #same
-        spec_info = scheduled_batch.spec_info
-        spec_info.verified_id = ret.verified_id
-        # spec_info.logits = logits_output.next_token_logits
-        spec_info.hidden_states = verify_input.hidden_states[ret.accepted_indices]
-        spec_info.accept_length = ret.accept_length
-        # spec_info.accept_index = ret.accepted_indices
-        logits_output.spec_info = spec_info
-        return logits_output
-
-    def spec_postprocess(self, scheduled_batch:ScheduleBatch, batch_output:BatchResult, async_overlap:bool=False):
-        draft_token_num = self.server_args.speculative_num_draft_tokens
-        last_verify_id_start = 0
-        
-        if async_overlap:
-            spec_info = batch_output.spec_info
-            accept_length_cpu = spec_info.accept_length_cpu
-            out_cache_loc_cpu = batch_output.out_cache_loc
-        else:
-            spec_info = scheduled_batch.spec_info
-            accept_length_cpu = spec_info.accept_length.cpu()
-            spec_info.accept_length_cpu = accept_length_cpu
-            accept_length_cpu = accept_length_cpu.clamp(min=0)
-            out_cache_loc_cpu = scheduled_batch.forward_batch.out_cache_loc.cpu()
-            batch_output.next_token_ids = batch_output.next_token_ids[:(1+accept_length_cpu).sum()]
-            spec_info.verified_id = spec_info.verified_id[:(1+accept_length_cpu).sum()]
-            spec_info.hidden_states = spec_info.hidden_states[:(1+accept_length_cpu).sum()]
-
-        # the prefill batch won't have accept_index
-        # hanlde out_cache_loc_lazy
-        if spec_info.out_cache_loc is not None:
-            # spec_info.accept_index = spec_info.accept_index[spec_info.accept_index!=-1]
-            # accept_index = spec_info.accept_index.cpu()
-            # evict_mask = torch.full((len(scheduled_batch)*draft_token_num,), True, dtype=torch.bool)
-            # evict_mask[accept_index] = False
-            accept_out_cache_loc = spec_info.out_cache_loc.cpu() # in overlap mode,spec_info.out_cache_loc is in CPU already
-            accept_cache_loc_list = accept_out_cache_loc[accept_out_cache_loc != -1].tolist()
-            refused_cache_loc = list(set(out_cache_loc_cpu.tolist())-set(accept_cache_loc_list))
-            assert len(refused_cache_loc)+len(accept_cache_loc_list) == len(out_cache_loc_cpu)
-            self.main_mem_pool.free_block(refused_cache_loc)
-            if not async_overlap:
-                for idx, sequence in enumerate(scheduled_batch):
-                    ############### adjust out_cache_loc ##################
-                    # the final token is un-determined before the forward, 
-                    # we have to alloc num-draft-token cache loc per batch. After, we need to adjust it here
-                    sequence.out_cache_loc = sequence.out_cache_loc[: -draft_token_num]
-                    accept_len = accept_length_cpu[idx].item()+1
-                    sequence.out_cache_loc.extend(accept_cache_loc_list[: accept_len])
-                    accept_cache_loc_list = accept_cache_loc_list[accept_len:]
-                    # for async overlap ????
-                    # sequence.accept_index = spec_info.accept_index[last_verify_id_start:end]
-            else:
-                num_steps = self.speculative_num_steps
-                for idx, sequence in enumerate(scheduled_batch):
-                    accept_len = accept_length_cpu[idx].item()
-                    start = draft_token_num + num_steps
-                    # -1 means the root token, we have kept it in the last step
-                    sequence.out_cache_loc[-start: -start + accept_len] = accept_cache_loc_list[1: 1+accept_len]
-                    sequence.out_cache_loc[-start + accept_len:-start + num_steps] = []
-                    accept_cache_loc_list = accept_cache_loc_list[1+accept_len:]
-
-                ######################################################
-        # but we will alloc draft_steps+1 tokens cache loc per sequence, so also need to free the unused ones
-        if async_overlap:
-            num_steps = self.speculative_num_steps
-            num_draft_tokens = self.server_args.speculative_num_draft_tokens
-            for idx, seq in enumerate(scheduled_batch):
-                ac_len = batch_output.spec_info.accept_length_cpu[idx].item()
-                offset = len(seq.out_cache_loc_spec) - (num_steps-ac_len)
-                seq.out_cache_loc_spec, extral_loc = seq.out_cache_loc_spec[
-                    :offset], seq.out_cache_loc_spec[offset:]
-                self.draft_mem_pool.free_block(extral_loc, force_sort=True)
-                # we can't release the verify loc here, but we can set it as neg to indicate unknown yet
-                # the root token is alway accepted, so we can keep one less
-                offset = len(seq.out_cache_loc) - (num_draft_tokens-1)
-                seq.out_cache_loc, seq.out_cache_loc_lazy_cpu = seq.out_cache_loc[
-                    :offset], seq.out_cache_loc[offset:]
-                # placeholder for the final accepted token loc
-                seq.out_cache_loc.extend([-1] * (num_steps))#TODO +1 or not?
-                seq.marked = True
-
-        if not async_overlap:
-            for idx, sequence in enumerate(scheduled_batch):
-                if sequence.status.is_active():
-                    sequence.accept_length = spec_info.accept_length[idx:idx+1]
-                    sequence.accept_length_cpu = spec_info.accept_length.cpu()[idx:idx+1]
-                    accept_length = accept_length_cpu[idx].item()
-                    end = last_verify_id_start+accept_length+1
-                    sequence.verified_id = spec_info.verified_id[last_verify_id_start:end]
-                    # sequence.logits = spec_info.logits[last_verify_id_start:end] # keep batch dim
-                    sequence.hidden_states = spec_info.hidden_states[last_verify_id_start:end]
-                    last_verify_id_start = end
-        if self.server_args.enable_debug:
-            acn = accept_length_cpu.clamp(min=0).sum().item()
-            self.total_accepted_tokens += acn
-            logger.info(f"Speculative decoding: accepted {(acn)} tokens, total accepted {self.total_accepted_tokens}.")
-        return scheduled_batch
+        return verify_input

--- a/python/sfllm/spec_decoding/spec_common.py
+++ b/python/sfllm/spec_decoding/spec_common.py
@@ -49,6 +49,7 @@ class SpeculativeAlgorithm(IntEnum):
     NONE = auto()
     EAGLE = auto()
     EAGLE3 = auto()
+    DFLASH2 = auto()
 
     def is_none(self):
         return self == SpeculativeAlgorithm.NONE
@@ -64,6 +65,7 @@ class SpeculativeAlgorithm(IntEnum):
         name_map = {
             "EAGLE": SpeculativeAlgorithm.EAGLE,
             "EAGLE3": SpeculativeAlgorithm.EAGLE3,
+            "DFLASH2": SpeculativeAlgorithm.DFLASH2,
             None: SpeculativeAlgorithm.NONE,
         }
         if name is not None:

--- a/python/sfllm/spec_decoding/spec_e2e_cuda_graph_runner.py
+++ b/python/sfllm/spec_decoding/spec_e2e_cuda_graph_runner.py
@@ -4,7 +4,7 @@ from typing import Callable
 import tqdm
 import torch
 
-class EagleE2ECudaGraphRunner():
+class SpeculativeE2ECudaGraphRunner():
     def __init__(self, draft_model_runner, target_model_runner, model_func:Callable):
         self.device_id = draft_model_runner.device_id
         self.draft_model_runner = draft_model_runner
@@ -32,6 +32,9 @@ class EagleE2ECudaGraphRunner():
         self.input_ids = draft_model_runner.input_ids
         self.verified_id = torch.zeros((4096,), dtype=torch.long, device=self.device_id)
         self.position_ids = draft_model_runner.position_ids
+        # Capture warmup requires valid token and RoPE indices.
+        self.input_ids.zero_()
+        self.position_ids.zero_()
         self.spec_kv_indices_mtd_buffer = torch.zeros_like(draft_model_runner.kv_indices_buffer)
         self.spec_out_cache_loc = draft_model_runner.out_cache_loc
         self.spec_position_ids_extend = torch.zeros_like(self.position_ids)
@@ -46,11 +49,21 @@ class EagleE2ECudaGraphRunner():
         self.cuda_graphs = {}
         self.graph_pool  = draft_model_runner.graph_pool
         self.graph_outputs = {}
-        # new buffers
-        self.logits_buffer = torch.empty(
-            (self.server_args.cuda_graph_max_bs, 
-             draft_model_runner.get_config().draft_vocab_size), dtype=torch.float16, device=draft_model_runner.device_id)
-
+        max_batch_size = int(self.server_args.cuda_graph_max_bs)
+        requested_batch_sizes = self.server_args.cuda_graph_bs
+        self.capture_batch_sizes = sorted(
+            set(requested_batch_sizes or range(1, max_batch_size + 1))
+        )
+        invalid_batch_sizes = [
+            batch_size
+            for batch_size in self.capture_batch_sizes
+            if batch_size < 1 or batch_size > max_batch_size
+        ]
+        if invalid_batch_sizes:
+            raise ValueError(
+                "CUDA Graph batch sizes must be in "
+                f"[1, {max_batch_size}], got {invalid_batch_sizes}."
+            )
     def prepare_cudagraph_inputs_for_capture(self, batch_size:int):
         from sfllm.spec_decoding.spec_utils import EagleSpecInput
         from sfllm.engine.schedule_batch import ScheduleBatch
@@ -113,7 +126,10 @@ class EagleE2ECudaGraphRunner():
         self.server_args.enable_debug = old_DEBUG
         self.compute_stream.synchronize()
         with freeze_gc(False):
-            for batch_size in tqdm.tqdm(list(reversed(range(1, 32))), desc="Capturing CUDA Graphs"):
+            for batch_size in tqdm.tqdm(
+                list(reversed(self.capture_batch_sizes)),
+                desc="Capturing speculative end-to-end CUDA Graphs",
+            ):
                 (scheduled_batch) = self.prepare_cudagraph_inputs_for_capture(batch_size)
                 cudagraph = torch.cuda.CUDAGraph()
 
@@ -123,7 +139,7 @@ class EagleE2ECudaGraphRunner():
                 self.graph_outputs[batch_size] = output
                 self.cuda_graphs[batch_size] = cudagraph
            
-        self.cuda_graphs[1].replay()
+        self.cuda_graphs[self.capture_batch_sizes[0]].replay()
 
     # @torch.compile
     def prepare_replay(self, scheduled_batch):

--- a/python/sfllm/spec_decoding/spec_worker.py
+++ b/python/sfllm/spec_decoding/spec_worker.py
@@ -1,0 +1,264 @@
+import logging
+from typing import Callable
+
+import torch
+
+from sfllm.engine.forward_params import ForwardMode
+from sfllm.engine.model_runner import ModelRunner
+from sfllm.engine.schedule_batch import BatchResult, ScheduleBatch
+from sfllm.server_args import ServerArgs
+from sfllm.spec_decoding.spec_e2e_cuda_graph_runner import (
+    SpeculativeE2ECudaGraphRunner,
+)
+from sfllm.spec_decoding.spec_utils import EagleVerifyInput
+
+logger = logging.getLogger(__name__)
+
+
+class SpeculativeWorker:
+    """Shared worker-side implementation of SFLLM's speculative protocol."""
+
+    def __init__(self, server_args: ServerArgs) -> None:
+        self.server_args = server_args
+        self.total_accepted_tokens = 0
+        self.draft_model_runner = ModelRunner(server_args, is_draft=True)
+        self.target_model_runner = ModelRunner(server_args)
+
+        target_model = self.target_model_runner.model
+        server_args.model_config = target_model.config
+        self.tokenizer = self.target_model_runner.tokenizer
+        self.detokenize = self.target_model_runner.detokenize
+        self.compute_stream = self.target_model_runner.compute_stream
+        self.dtype = self.target_model_runner.dtype
+        self.config = target_model.config
+        self.draft_model_runner.wrap_target_model(self.target_model_runner)
+
+    @property
+    def main_mem_pool(self):
+        return self.target_model_runner.block_memory_manager
+
+    @property
+    def draft_mem_pool(self):
+        return self.draft_model_runner.block_memory_manager
+
+    def init_memory_pools(self) -> None:
+        self.target_model_runner.init_memory_pool()
+        self.draft_model_runner.init_memory_pool(
+            num_blocks=self.target_model_runner.block_memory_manager.num_blocks
+        )
+
+    def init_e2e_runner(self, model_func: Callable) -> None:
+        self.e2e_runner = SpeculativeE2ECudaGraphRunner(
+            self.draft_model_runner,
+            self.target_model_runner,
+            model_func,
+        )
+
+    def init_capture_cudagraph(self) -> None:
+        if not self.server_args.disable_cuda_graph:
+            self.e2e_runner.init_cuda_graph()
+
+    def forward_e2e(self, scheduled_batch: ScheduleBatch) -> BatchResult:
+        return self.forward_decode_e2e_post_process(
+            scheduled_batch,
+            *self.e2e_runner.forward(scheduled_batch),
+        )
+
+    def commit_previous(self, scheduled_batch: ScheduleBatch) -> None:
+        """Advance draft state with the tokens accepted in the previous round."""
+        raise NotImplementedError
+
+    def proposal(self, scheduled_batch: ScheduleBatch) -> EagleVerifyInput:
+        """Build algorithm-specific candidates in the shared verify format."""
+        raise NotImplementedError
+
+    def _adapt_verified_hidden_states(
+        self, scheduled_batch: ScheduleBatch, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        """Adapt target states to the representation kept for the next step."""
+        return hidden_states
+
+    def verify(
+        self, scheduled_batch: ScheduleBatch, proposal: EagleVerifyInput
+    ) -> BatchResult:
+        """Run the target model for a speculative proposal."""
+        scheduled_batch.position_ids = proposal.positions
+        scheduled_batch.input_ids = proposal.draft_token
+        forward_batch = scheduled_batch.forward_batch
+        forward_batch.forward_mode = ForwardMode.TARGET_VERIFY
+        forward_batch.custom_mask = proposal.custom_mask
+
+        verification = self.target_model_runner.forward(scheduled_batch)
+        forward_batch.forward_mode = ForwardMode.DECODE
+        hidden_states = torch.cat(verification.aux_hidden_states, dim=-1)
+        proposal.hidden_states = self._adapt_verified_hidden_states(
+            scheduled_batch, hidden_states
+        )
+        return verification
+
+    def accept(
+        self,
+        scheduled_batch: ScheduleBatch,
+        proposal: EagleVerifyInput,
+        verification: BatchResult,
+    ):
+        """Select the path accepted by the target model."""
+        accept_index, accept_length, predict = proposal.verify(
+            scheduled_batch, verification, 1
+        )
+        return (
+            proposal,
+            verification.next_token_logits,
+            accept_index,
+            accept_length,
+            predict,
+        )
+
+    def verify_propose(
+        self, scheduled_batch: ScheduleBatch, proposal: EagleVerifyInput
+    ):
+        """Compatibility wrapper for Eagle's combined verify/accept call."""
+        verification = self.verify(scheduled_batch, proposal)
+        return self.accept(scheduled_batch, proposal, verification)
+
+    def forward_decode_e2e(self, scheduled_batch: ScheduleBatch):
+        self.commit_previous(scheduled_batch)
+        proposal = self.proposal(scheduled_batch)
+        verification = self.verify(scheduled_batch, proposal)
+        return self.accept(scheduled_batch, proposal, verification)
+
+    def forward_decode_e2e_post_process(
+        self,
+        scheduled_batch: ScheduleBatch,
+        verify_input: EagleVerifyInput,
+        next_token_logits: torch.Tensor,
+        accept_index: torch.Tensor,
+        accept_length: torch.Tensor,
+        predict: torch.Tensor,
+    ) -> BatchResult:
+        """Publish verified tokens, hidden states, and KV locations."""
+        result = verify_input.verify_post_process(
+            scheduled_batch, accept_index, accept_length, predict
+        )
+        spec_info = scheduled_batch.spec_info
+        spec_info.verified_id = result.verified_id
+        spec_info.hidden_states = verify_input.hidden_states[result.accepted_indices]
+        spec_info.accept_length = result.accept_length
+        return BatchResult(
+            next_token_ids=result.verified_id,
+            next_token_logits=next_token_logits,
+            aux_hidden_states=None,
+            spec_info=spec_info,
+        )
+
+    def spec_postprocess(
+        self,
+        scheduled_batch: ScheduleBatch,
+        batch_output: BatchResult,
+        async_overlap: bool = False,
+    ) -> ScheduleBatch:
+        draft_token_num = self.server_args.speculative_num_draft_tokens
+        last_verify_id_start = 0
+
+        if async_overlap:
+            spec_info = batch_output.spec_info
+            accept_length_cpu = spec_info.accept_length_cpu
+            out_cache_loc_cpu = batch_output.out_cache_loc
+        else:
+            spec_info = scheduled_batch.spec_info
+            accept_length_cpu = spec_info.accept_length.cpu()
+            spec_info.accept_length_cpu = accept_length_cpu
+            accept_length_cpu = accept_length_cpu.clamp(min=0)
+            out_cache_loc_cpu = scheduled_batch.forward_batch.out_cache_loc.cpu()
+            accepted_count = (1 + accept_length_cpu).sum()
+            batch_output.next_token_ids = batch_output.next_token_ids[:accepted_count]
+            spec_info.verified_id = spec_info.verified_id[:accepted_count]
+            spec_info.hidden_states = spec_info.hidden_states[:accepted_count]
+
+        if spec_info.out_cache_loc is not None:
+            accepted_cache_locs = spec_info.out_cache_loc.cpu()
+            accepted_cache_locs = accepted_cache_locs[
+                accepted_cache_locs != -1
+            ].tolist()
+            rejected_cache_locs = list(
+                set(out_cache_loc_cpu.tolist()) - set(accepted_cache_locs)
+            )
+            assert len(rejected_cache_locs) + len(accepted_cache_locs) == len(
+                out_cache_loc_cpu
+            )
+            self.main_mem_pool.free_block(rejected_cache_locs)
+
+            if not async_overlap:
+                for idx, sequence in enumerate(scheduled_batch):
+                    sequence.out_cache_loc = sequence.out_cache_loc[:-draft_token_num]
+                    accept_len = accept_length_cpu[idx].item() + 1
+                    sequence.out_cache_loc.extend(accepted_cache_locs[:accept_len])
+                    accepted_cache_locs = accepted_cache_locs[accept_len:]
+            else:
+                num_steps = self.server_args.speculative_num_steps
+                for idx, sequence in enumerate(scheduled_batch):
+                    accept_len = accept_length_cpu[idx].item()
+                    sequence_cache_locs = accepted_cache_locs[: 1 + accept_len]
+                    accepted_cache_locs = accepted_cache_locs[1 + accept_len :]
+                    if not sequence.status.is_active():
+                        # The sequence owns the root; this in-flight result owns
+                        # the accepted proposal slots that follow it.
+                        self.main_mem_pool.free_block(sequence_cache_locs[1:])
+                        continue
+                    start = draft_token_num + num_steps
+                    sequence.out_cache_loc[-start : -start + accept_len] = (
+                        sequence_cache_locs[1:]
+                    )
+                    sequence.out_cache_loc[
+                        -start + accept_len : -start + num_steps
+                    ] = []
+
+        if async_overlap:
+            num_steps = self.server_args.speculative_num_steps
+            for idx, sequence in enumerate(scheduled_batch):
+                if not sequence.status.is_active():
+                    continue
+                accept_len = batch_output.spec_info.accept_length_cpu[idx].item()
+                offset = len(sequence.out_cache_loc_spec) - (num_steps - accept_len)
+                sequence.out_cache_loc_spec, extra_locs = (
+                    sequence.out_cache_loc_spec[:offset],
+                    sequence.out_cache_loc_spec[offset:],
+                )
+                self.draft_mem_pool.free_block(extra_locs)
+
+                offset = len(sequence.out_cache_loc) - (draft_token_num - 1)
+                sequence.out_cache_loc, sequence.out_cache_loc_lazy_cpu = (
+                    sequence.out_cache_loc[:offset],
+                    sequence.out_cache_loc[offset:],
+                )
+                sequence.out_cache_loc.extend([-1] * num_steps)
+                sequence.marked = True
+
+        if not async_overlap:
+            for idx, sequence in enumerate(scheduled_batch):
+                if not sequence.status.is_active():
+                    continue
+                sequence.accept_length = spec_info.accept_length[idx : idx + 1]
+                sequence.accept_length_cpu = spec_info.accept_length.cpu()[
+                    idx : idx + 1
+                ]
+                accept_length = accept_length_cpu[idx].item()
+                end = last_verify_id_start + accept_length + 1
+                sequence.verified_id = spec_info.verified_id[last_verify_id_start:end]
+                sequence.hidden_states = spec_info.hidden_states[
+                    last_verify_id_start:end
+                ]
+                last_verify_id_start = end
+
+        if self.server_args.enable_debug:
+            accepted = accept_length_cpu.clamp(min=0).sum().item()
+            self.total_accepted_tokens += accepted
+            logger.info(
+                "Speculative decoding: accepted %s tokens, total accepted %s.",
+                accepted,
+                self.total_accepted_tokens,
+            )
+        return scheduled_batch
+
+
+__all__ = ["SpeculativeWorker"]


### PR DESCRIPTION
## Summary

- add a Qwen3 DFlash2 draft model, block-local convolution, selector, and capture-safe Triton kernels
- share the speculative lifecycle as `commit_previous -> proposal -> verify -> accept` across Eagle3 and DFlash2
- reuse the existing overlap scheduler, request metadata, target verification, acceptance, KV ownership, and end-to-end CUDA Graph runner
- rename the shared runner from Eagle-specific naming to `SpeculativeE2ECudaGraphRunner`
- keep dimensions checkpoint-driven; Qwen3-4B dense greedy decoding is the currently validated configuration

## Design

DFlash2-specific behavior is confined to its model, kernels, and proposal worker. There is no DFlash2 scheduler state, request state, accept path, pack path, delayed-release protocol, or separate graph runner.

The Eagle3 worker retains its proposal implementation while initialization, verification, acceptance, postprocessing, and graph orchestration move to the shared speculative worker.

## Validation

Offline inference only; no server was started.

- DFlash2 batch 1: 1000 generated tokens; 781 decode replays, all captured
- DFlash2 ragged batch 8: 8000 total generated tokens, 1000 average per request; 956 replays across batch sizes 1-8, all captured
- fresh ragged smoke: request lengths 17 and 23; 22/22 graph replays captured; target and draft KV deltas both zero
- Eagle3 A/B: the active decode path produced 1000/1000 identical token IDs and identical text before and after the shared-worker refactor
- the legacy Eagle3 completion path reproduced a duplicate draft-KV free after 457 decode steps; the shared ownership handling completes and returns both KV pools to baseline
- Nsight Systems verified end-to-end graph launches and graph-node execution for DFlash2, plus full-graph Eagle3 regression coverage
- Python compilation and `git diff --check` pass

## Numerical note

Target-only grouped decode and speculative target verification use different attention reduction tilings. Near-tied BF16 logits can therefore select different argmax tokens; this is not a speculative KV, mask, overlap, or CUDA Graph state error.