### PR TITLE
feat(sfkernels): add fused normalization, gating, and partial RoPE

### DIFF
--- a/sfkernels/csrc/common_extension.cc
+++ b/sfkernels/csrc/common_extension.cc
@@ -27,8 +27,11 @@ TORCH_LIBRARY_FRAGMENT(sfkernels, m) {
      /*
    * From csrc/elementwise
    */
-  m.def("rmsnorm(Tensor! output, Tensor input, Tensor weight, float eps, Tensor? input_2=None) -> ()");
+  m.def("rmsnorm(Tensor! output, Tensor input, Tensor weight, float eps, Tensor!? input_2=None, bool gemma_style=False) -> ()");
   m.impl("rmsnorm", torch::kCUDA, &rmsnorm);
+
+  m.def("gated_rmsnorm(Tensor! output, Tensor input, Tensor gate, Tensor weight, float eps) -> ()");
+  m.impl("gated_rmsnorm", torch::kCUDA, &gated_rmsnorm);
 
   // m.def("fused_add_rmsnorm(Tensor! input, Tensor! residual, Tensor weight, float eps, bool enable_pdl) -> ()");
   // m.impl("fused_add_rmsnorm", torch::kCUDA, &sgl_fused_add_rmsnorm);
@@ -53,6 +56,15 @@ TORCH_LIBRARY_FRAGMENT(sfkernels, m) {
       "Tensor k_norm_weight, Tensor cos_sin_cache, Tensor pos_ids, bool interleave, "
       "Tensor! k_buffer, Tensor! v_buffer, Tensor kv_cache_loc, float epsilon) -> ()");
   m.impl("qk_norm_rope_and_cache", torch::kCUDA, &qk_norm_rope_and_cache);
+
+  m.def(
+      "gemma_qk_norm_rope(Tensor q, Tensor k, Tensor v, Tensor! q_rope, Tensor! k_rope, "
+      "Tensor q_norm_weight, Tensor k_norm_weight, Tensor cos_sin_cache, Tensor pos_ids, "
+      "Tensor!? k_buffer, Tensor!? v_buffer, Tensor? kv_cache_loc, float epsilon) -> ()");
+  m.impl("gemma_qk_norm_rope", torch::kCUDA, &gemma_qk_norm_rope);
+
+  m.def("fused_sigmoid_mul(Tensor! output, Tensor gate) -> ()");
+  m.impl("fused_sigmoid_mul", torch::kCUDA, &fused_sigmoid_mul);
 
   // quantization fp8 ops
   m.def("sgl_per_tensor_quant_fp8(Tensor input, Tensor output_q, Tensor output_s, bool is_static) -> ()");

--- a/sfkernels/csrc/elementwise/activation.cu
+++ b/sfkernels/csrc/elementwise/activation.cu
@@ -28,58 +28,93 @@
 #include "hip/hip_act_and_mul.cuh"
 #endif
 
+#include "cast.cuh"
+
 // Adapted from flashinfer activation
 // https://github.com/flashinfer-ai/flashinfer/blob/4e8eb1879f9c3ba6d75511e5893183bf8f289a62/csrc/activation.cu#L44
 
-namespace detail {
-
-template <typename T>
-__device__ __forceinline__ float to_f32(const T& x) {
-#if USE_ROCM
-  return castToFloat(x);
-#else
-  return static_cast<float>(x);
-#endif
-}
-
-template <typename T>
-__device__ __forceinline__ T from_f32(float f32) {
-#if USE_ROCM
-  return castFromFloat<T>(f32);
-#else
-  return static_cast<T>(f32);
-#endif
-}
-
-}  // namespace detail
-
 template <typename T>
 __device__ __forceinline__ T silu(const T& x) {
-  float f32_val = detail::to_f32(x);
-  return detail::from_f32<T>(f32_val / (1.0f + expf(-f32_val)));
+  float f32_val = to_float(x);
+  return from_float<T>(f32_val / (1.0f + expf(-f32_val)));
 }
+
+#ifndef USE_ROCM
+// Flatten vectors across tokens so small decode batches launch enough blocks.
+template <typename T>
+__global__ void silu_and_mul_flat_kernel(
+    T* __restrict__ out,
+    const T* __restrict__ input,
+    const uint32_t d,
+    const uint32_t num_tokens) {
+  constexpr uint32_t vec_size = 16 / sizeof(T);
+  const uint32_t vecs_per_token = d / vec_size;
+  const uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= num_tokens * vecs_per_token) {
+    return;
+  }
+
+  const uint32_t token = index / vecs_per_token;
+  const uint32_t column = (index % vecs_per_token) * vec_size;
+  const uint32_t input_offset = token * 2 * d + column;
+  flashinfer::vec_t<float, vec_size> gate, up, output;
+  gate.cast_load(input + input_offset);
+  up.cast_load(input + input_offset + d);
+#pragma unroll
+  for (uint32_t i = 0; i < vec_size; ++i) {
+    output[i] = silu(gate[i]) * up[i];
+  }
+  output.cast_store(out + token * d + column);
+}
+
+template <typename T>
+__global__ void fused_sigmoid_mul_kernel(
+    T* __restrict__ output,
+    const T* __restrict__ gate,
+    const uint64_t num_rows,
+    const uint32_t num_heads,
+    const uint32_t head_dim,
+    const int64_t gate_token_stride,
+    const int64_t gate_head_stride) {
+  const uint64_t row = static_cast<uint64_t>(blockIdx.x) * blockDim.y + threadIdx.y;
+  if (row >= num_rows) {
+    return;
+  }
+  const uint64_t token = row / num_heads;
+  const uint32_t head = row % num_heads;
+  const int64_t gate_offset = token * gate_token_stride +
+      head * gate_head_stride;
+  for (uint32_t column = threadIdx.x; column < head_dim; column += blockDim.x) {
+    const uint64_t index = row * head_dim + column;
+    const float value = to_float(output[index]);
+    const float gate_value = to_float(gate[gate_offset + column]);
+    output[index] = from_float<T>(
+        value * __fdividef(1.0f, 1.0f + __expf(-gate_value)));
+  }
+}
+#endif
 
 template <typename T>
 __device__ __forceinline__ T gelu(const T& x) {
   constexpr float kAlpha = M_SQRT1_2;
-  float f32_val = detail::to_f32(x);
-  return detail::from_f32<T>(f32_val * (0.5f * (1.0f + erf(f32_val * kAlpha))));
+  float f32_val = to_float(x);
+  return from_float<T>(f32_val * (0.5f * (1.0f + erf(f32_val * kAlpha))));
 }
 
 // gelu_quick(x) = x * torch.sigmoid(1.702 * x)
 template <typename T>
 __device__ __forceinline__ T gelu_quick_act(const T& x) {
-  float f32_val = detail::to_f32(x);
-  return detail::from_f32<T>(f32_val / (1.0f + expf(-f32_val * 1.702f)));
+  float f32_val = to_float(x);
+  return from_float<T>(f32_val / (1.0f + expf(-f32_val * 1.702f)));
 }
 
 template <typename T>
 __device__ __forceinline__ T gelu_tanh(const T& x) {
   constexpr float kAlpha = 0.044715f;
   constexpr float kBeta = 0.7978845608028654f;
-  float f32_val = detail::to_f32(x);
+  float f32_val = to_float(x);
   const float cdf = 0.5f * (1.0f + tanhf((kBeta * (f32_val + kAlpha * f32_val * f32_val * f32_val))));
-  return detail::from_f32<T>(f32_val * cdf);
+  return from_float<T>(f32_val * cdf);
 }
 
 // Helpers to avoid #if inside macro arguments
@@ -119,16 +154,75 @@ void launch_gelu_tanh_kernel(at::Tensor& out, at::Tensor& input, int d, dim3 gri
 void silu_and_mul(at::Tensor& out, at::Tensor& input) {
   int d = input.size(-1) / 2;
   int64_t num_tokens = input.numel() / input.size(-1);
-  dim3 grid(num_tokens);
 
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(input.scalar_type(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
+#ifndef USE_ROCM
+    if (d % vec_size == 0) {
+      constexpr uint32_t block_size = 256;
+      uint32_t num_vectors = num_tokens * d / vec_size;
+      dim3 grid((num_vectors + block_size - 1) / block_size);
+      silu_and_mul_flat_kernel<c_type>
+          <<<grid, block_size, 0, stream>>>(
+              static_cast<c_type*>(out.data_ptr()),
+              static_cast<c_type*>(input.data_ptr()),
+              d,
+              num_tokens);
+      return true;
+    }
+#endif
+    dim3 grid(num_tokens);
     dim3 block(std::min(d / vec_size, 1024U));
     launch_silu_kernel<c_type>(out, input, d, grid, block, stream);
     return true;
+  });
+}
+
+void fused_sigmoid_mul(at::Tensor& output, const at::Tensor& gate) {
+  CHECK_INPUT(output);
+  TORCH_CHECK(output.dim() == 2 && (gate.dim() == 2 || gate.dim() == 3),
+              "output must be 2D and gate must be 2D or 3D");
+  TORCH_CHECK(gate.is_cuda() && gate.stride(-1) == 1,
+              "gate must be a CUDA tensor contiguous in its last dimension");
+  TORCH_CHECK(output.device() == gate.device(), "output and gate must be on the same device");
+  TORCH_CHECK(output.scalar_type() == gate.scalar_type(), "output and gate must have the same dtype");
+
+  const uint32_t num_heads = gate.dim() == 3 ? gate.size(1) : 1;
+  const uint32_t head_dim = gate.size(-1);
+  TORCH_CHECK(output.size(0) == gate.size(0) &&
+              output.size(1) == static_cast<int64_t>(num_heads) * head_dim,
+              "output and gate shapes do not match");
+
+  const uint64_t num_elements = output.numel();
+  if (num_elements == 0) {
+    return;
+  }
+
+  const int64_t gate_token_stride = gate.stride(0);
+  const int64_t gate_head_stride = gate.dim() == 3 ? gate.stride(1) : 0;
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(output));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(output.scalar_type(), c_type, [&] {
+#ifndef USE_ROCM
+    const uint64_t num_rows = num_elements / head_dim;
+    const dim3 block(32, 4);
+    const dim3 grid((num_rows + block.y - 1) / block.y);
+    fused_sigmoid_mul_kernel<c_type>
+        <<<grid, block, 0, stream>>>(
+            static_cast<c_type*>(output.data_ptr()),
+            static_cast<const c_type*>(gate.data_ptr()),
+            num_rows,
+            num_heads,
+            head_dim,
+            gate_token_stride,
+            gate_head_stride);
+    return true;
+#else
+    TORCH_CHECK(false, "fused_sigmoid_mul is only available on CUDA");
+#endif
   });
 }
 

--- a/sfkernels/csrc/elementwise/layernorm.cu
+++ b/sfkernels/csrc/elementwise/layernorm.cu
@@ -1,5 +1,6 @@
 #include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <cub/cub.cuh>
 #include "utils.h"
 #include "cast.cuh"
@@ -11,6 +12,104 @@ struct SumOp {
         return a + b;
     }
 };
+
+constexpr int kGatedRmsNormThreads = 128;
+
+template <typename scalar_t>
+__global__ void gated_rms_norm_kernel(
+    scalar_t* __restrict__ output,
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ gate,
+    const float* __restrict__ weight,
+    const float epsilon,
+    const int num_heads,
+    const int hidden_size,
+    const int64_t input_token_stride,
+    const int64_t input_head_stride,
+    const int64_t gate_token_stride,
+    const int64_t gate_head_stride) {
+    using BlockReduce = cub::BlockReduce<float, kGatedRmsNormThreads>;
+    __shared__ typename BlockReduce::TempStorage reduce_storage;
+    __shared__ float inverse_rms;
+
+    const int64_t row = blockIdx.x;
+    const int64_t token = row / num_heads;
+    const int head = row % num_heads;
+    const int64_t input_offset =
+        token * input_token_stride + head * input_head_stride;
+    float sum = 0.0f;
+    for (int column = threadIdx.x; column < hidden_size; column += blockDim.x) {
+        const float value = to_float(input[input_offset + column]);
+        sum += value * value;
+    }
+    const float square_sum = BlockReduce(reduce_storage).Reduce(
+        sum, SumOp{});
+    if (threadIdx.x == 0) {
+        inverse_rms = rsqrtf(square_sum / hidden_size + epsilon);
+    }
+    __syncthreads();
+
+    for (int column = threadIdx.x; column < hidden_size; column += blockDim.x) {
+        const float value = to_float(input[input_offset + column]);
+        const int64_t gate_offset =
+            token * gate_token_stride + head * gate_head_stride + column;
+        const float gate_value = to_float(gate[gate_offset]);
+        const float gated = gate_value / (1.0f + expf(-gate_value));
+        output[row * hidden_size + column] = from_float<scalar_t>(
+            value * inverse_rms * weight[column] * gated);
+    }
+}
+
+void gated_rmsnorm(
+    at::Tensor& output,
+    const at::Tensor& input,
+    const at::Tensor& gate,
+    const at::Tensor& weight,
+    double eps) {
+    CHECK_LAST_DIM_CONTIGUOUS_INPUT(input);
+    CHECK_LAST_DIM_CONTIGUOUS_INPUT(gate);
+    CHECK_INPUT(weight);
+    CHECK_INPUT(output);
+    TORCH_CHECK(input.dim() == 3, "input must have shape [tokens, heads, dim]");
+    TORCH_CHECK(gate.sizes() == input.sizes(), "gate shape must match input");
+    TORCH_CHECK(output.sizes() == input.sizes(), "output shape must match input");
+    TORCH_CHECK(gate.scalar_type() == input.scalar_type(),
+                "gate and input must have the same dtype");
+    TORCH_CHECK(output.scalar_type() == input.scalar_type(),
+                "output and input must have the same dtype");
+    TORCH_CHECK(input.device() == gate.device() && input.device() == output.device() &&
+                input.device() == weight.device(), "all tensors must be on the same device");
+    TORCH_CHECK(weight.scalar_type() == at::ScalarType::Float,
+                "weight must have float32 dtype");
+    const int num_heads = input.size(1);
+    const int hidden_size = input.size(2);
+    TORCH_CHECK(weight.dim() == 1 && weight.numel() == hidden_size,
+                "weight must have shape [", hidden_size, "]");
+    TORCH_CHECK(hidden_size > 0, "hidden size must be positive");
+
+    const int64_t num_rows = input.size(0) * num_heads;
+    if (num_rows == 0) {
+        return;
+    }
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), scalar_t, [&] {
+        gated_rms_norm_kernel<scalar_t>
+            <<<static_cast<uint32_t>(num_rows), kGatedRmsNormThreads, 0, stream>>>(
+                reinterpret_cast<scalar_t*>(output.data_ptr()),
+                reinterpret_cast<const scalar_t*>(input.data_ptr()),
+                reinterpret_cast<const scalar_t*>(gate.data_ptr()),
+                weight.data_ptr<float>(),
+                static_cast<float>(eps),
+                num_heads,
+                hidden_size,
+                input.stride(0),
+                input.stride(1),
+                gate.stride(0),
+                gate.stride(1));
+        return true;
+    });
+}
 
 template<typename T>
 __device__ __forceinline__ T mul(T a, T b) {
@@ -48,7 +147,7 @@ __global__ void rms_norm_kernel_opt_v2(
     const scalar_t* __restrict__ weight,  // [hidden_size]
     const float epsilon, const int num_tokens, const int hidden_size,
     const int rows_per_outer, const int64_t outer_stride,
-    const int64_t row_stride) {
+    const int64_t row_stride, const bool gemma_style) {
 
     using LoadT = aligned_vector<scalar_t, ILP>;
     scalar_t v[ILP];
@@ -119,12 +218,14 @@ __global__ void rms_norm_kernel_opt_v2(
                 if (input_res_for_this_vec != nullptr) {
                     *value_res = input_res_for_this_vec[idx];
                 }
+                const LoadT weights = weight_cache_vec[idx];
                 for(int j = 0; j < ILP; j++) {
                     float x = to_float(v[j]);
                     if (input_res_for_this_vec != nullptr) {
                         x += to_float(v_res[j]);
                     }
-                    float w = to_float(weight_cache[idx * ILP + j]);
+                    float w = to_float(weights[j])
+                        + static_cast<float>(gemma_style);
                     v[j] = from_float<scalar_t>(x * s_variance * w);
                     if (input_res_for_this_vec != nullptr) {
                         v_res[j] = from_float<scalar_t>(x);
@@ -141,7 +242,8 @@ __global__ void rms_norm_kernel_opt_v2(
 }
 
 void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, 
-            double eps,at::optional<at::Tensor> input_2=at::nullopt) {
+            double eps,at::optional<at::Tensor> input_2=at::nullopt,
+            bool gemma_style=false) {
     TORCH_CHECK(input.dim() > 0, "input must have at least one dimension");
     int hidden_size = input.size(-1);
     int num_tokens = input.numel() / hidden_size;
@@ -177,6 +279,9 @@ void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight,
     const int64_t row_stride = input.dim() == 3 ? input.stride(1) :
         (input.dim() == 1 ? hidden_size : input.stride(-2));
     
+    if (num_tokens == 0) {
+        return;
+    }
     DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), scalar_t, [&] {
         int shared_mem_size = hidden_size * sizeof(scalar_t) + ALIGN_BYTES;
         constexpr int ILP = 16 / sizeof(scalar_t); 
@@ -197,7 +302,7 @@ void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight,
             <<<grid, 256, shared_mem_size, stream>>>(
                 output_ptr, input_ptr, residual_ptr, weight_ptr,
                 static_cast<float>(eps), num_tokens, hidden_size,
-                rows_per_outer, outer_stride, row_stride);
+                rows_per_outer, outer_stride, row_stride, gemma_style);
         return true;
     });
 }

--- a/sfkernels/csrc/elementwise/pos_enc.cuh
+++ b/sfkernels/csrc/elementwise/pos_enc.cuh
@@ -18,6 +18,8 @@
 
 #include <flashinfer/pos_enc.cuh>  // upstream
 
+#include "cast.cuh"
+
 namespace flashinfer {
 
 namespace kv_buffer_saver {
@@ -69,7 +71,9 @@ __device__ __forceinline__ vec_t<float, vec_size> vec_apply_qk_norm_rope(
     const DType* weight,
     const vec_t<float, vec_size>& cos,
     const vec_t<float, vec_size>& sin,
-    float epsilon) {
+    float epsilon,
+    uint32_t rotary_dim,
+    float weight_bias) {
   vec_t<float, vec_size> values, weights, output;
   values.cast_load(input + threadIdx.x * vec_size);
   weights.cast_load(weight + threadIdx.x * vec_size);
@@ -88,7 +92,16 @@ __device__ __forceinline__ vec_t<float, vec_size> vec_apply_qk_norm_rope(
       __shfl_sync(active_mask, variance, 0, bdx) / (vec_size * bdx) + epsilon);
 #pragma unroll
   for (uint32_t i = 0; i < vec_size; ++i) {
-    values[i] *= inv_rms * weights[i];
+    values[i] = to_float(from_float<DType>(
+        values[i] * inv_rms * (weights[i] + weight_bias)));
+    output[i] = values[i];
+  }
+
+  const uint32_t rotary_threads = rotary_dim / vec_size;
+  const bool apply_rotary = threadIdx.x < rotary_threads;
+  const unsigned int rotary_mask = __ballot_sync(active_mask, apply_rotary);
+  if (!apply_rotary) {
+    return output;
   }
 
   if constexpr (interleave) {
@@ -100,9 +113,10 @@ __device__ __forceinline__ vec_t<float, vec_size> vec_apply_qk_norm_rope(
   } else {
 #pragma unroll
     for (uint32_t i = 0; i < vec_size; ++i) {
-      const float paired = __shfl_xor_sync(active_mask, values[i], bdx / 2, bdx);
+      const float paired = __shfl_xor_sync(
+          rotary_mask, values[i], rotary_threads / 2, bdx);
       output[i] = values[i] * cos[i] +
-                  (threadIdx.x < bdx / 2 ? -paired : paired) * sin[i];
+                  (threadIdx.x < rotary_threads / 2 ? -paired : paired) * sin[i];
     }
   }
   return output;
@@ -124,6 +138,7 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheEnhancedHeadParallelismKernel
     DType* q_norm_weight,
     DType* k_norm_weight,
     float qk_norm_epsilon,
+    float qk_norm_weight_bias,
     DType* q_rope,
     DType* k_rope,
     DType* k_buffer,
@@ -189,7 +204,8 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheEnhancedHeadParallelismKernel
       vec_t<float, vec_size> q_vec;
       if constexpr (apply_qk_norm) {
         q_vec = vec_apply_qk_norm_rope<interleave, vec_size, bdx>(
-            q_ptr, q_norm_weight, cos, sin, qk_norm_epsilon);
+            q_ptr, q_norm_weight, cos, sin, qk_norm_epsilon,
+            rotary_dim, qk_norm_weight_bias);
       } else if constexpr (interleave) {
         q_vec = vec_apply_llama_rope_cos_sin_interleave_reuse_half<vec_size, bdx>(q_ptr, cos, sin, rotary_dim);
       } else {
@@ -212,7 +228,8 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheEnhancedHeadParallelismKernel
       vec_t<float, vec_size> k_vec;
       if constexpr (apply_qk_norm) {
         k_vec = vec_apply_qk_norm_rope<interleave, vec_size, bdx>(
-            k_ptr, k_norm_weight, cos, sin, qk_norm_epsilon);
+            k_ptr, k_norm_weight, cos, sin, qk_norm_epsilon,
+            rotary_dim, qk_norm_weight_bias);
       } else if constexpr (interleave) {
         k_vec = vec_apply_llama_rope_cos_sin_interleave_reuse_half<vec_size, bdx>(k_ptr, cos, sin, rotary_dim);
       } else {
@@ -258,6 +275,7 @@ __global__ void BatchQKApplyRotaryPosIdsCosSinCacheEnhancedKernel(
     DType* q_norm_weight,
     DType* k_norm_weight,
     float qk_norm_epsilon,
+    float qk_norm_weight_bias,
     DType* q_rope,
     DType* k_rope,
     DType* k_buffer,
@@ -398,6 +416,7 @@ cudaError_t BatchQKApplyRotaryPosIdsCosSinCacheEnhanced(
     DType* q_norm_weight,
     DType* k_norm_weight,
     float qk_norm_epsilon,
+    float qk_norm_weight_bias,
     DType* q_rope,
     DType* k_rope,
     DType* k_buffer,
@@ -431,8 +450,10 @@ cudaError_t BatchQKApplyRotaryPosIdsCosSinCacheEnhanced(
     cudaStream_t stream = nullptr) {
   int dev_id = 0;
   int num_sms = 0;
-  FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
-  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
+  if (!apply_qk_norm) {
+    FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
+  }
 
 #define LAUNCH_KERNEL_RAW(kernel_name)                                \
   do {                                                                \
@@ -456,6 +477,7 @@ cudaError_t BatchQKApplyRotaryPosIdsCosSinCacheEnhanced(
         q_norm_weight,                                                \
         k_norm_weight,                                                \
         qk_norm_epsilon,                                              \
+        qk_norm_weight_bias,                                          \
         q_rope,                                                       \
         k_rope,                                                       \
         k_buffer,                                                     \
@@ -507,15 +529,29 @@ cudaError_t BatchQKApplyRotaryPosIdsCosSinCacheEnhanced(
             DType,
             IdType>;
 
-        int num_blocks_per_sm_0 = 0;
-        FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-            &num_blocks_per_sm_0, kernel_0, num_threads, /*smem_size=*/0));
-        uint32_t num_ctas_0 = num_blocks_per_sm_0 * num_sms;
-
-        if (!APPLY_QK_NORM && (nnz + bdy - 1) / bdy >= num_ctas_0) {
-          dim3 nblks(nblks_x);
-          dim3 nthrs(bdx, bdy);
-          LAUNCH_KERNEL_RAW(kernel_0);
+        if constexpr (!APPLY_QK_NORM) {
+          int num_blocks_per_sm_0 = 0;
+          FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+              &num_blocks_per_sm_0, kernel_0, num_threads, /*smem_size=*/0));
+          uint32_t num_ctas_0 = num_blocks_per_sm_0 * num_sms;
+          if ((nnz + bdy - 1) / bdy >= num_ctas_0) {
+            dim3 nblks(nblks_x);
+            dim3 nthrs(bdx, bdy);
+            LAUNCH_KERNEL_RAW(kernel_0);
+          } else {
+            dim3 nblks(nblks_x, num_qo_heads + num_kv_heads);
+            dim3 nthrs(bdx, bdy);
+            auto kernel_1 = BatchQKApplyRotaryPosIdsCosSinCacheEnhancedHeadParallelismKernel<
+                APPLY_QK_NORM,
+                SAVE_KV_CACHE,
+                INTERLEAVE,
+                HEAD_DIM,
+                vec_size,
+                bdx,
+                DType,
+                IdType>;
+            LAUNCH_KERNEL_RAW(kernel_1);
+          }
         } else {
           dim3 nblks(nblks_x, num_qo_heads + num_kv_heads);
           dim3 nthrs(bdx, bdy);

--- a/sfkernels/csrc/elementwise/rope.cu
+++ b/sfkernels/csrc/elementwise/rope.cu
@@ -41,9 +41,12 @@ void apply_rope_pos_ids_cos_sin_cache_impl(
     const std::optional<at::Tensor>& kv_cache_loc,
     const at::Tensor* q_norm_weight,
     const at::Tensor* k_norm_weight,
-    double qk_norm_epsilon) {
+    double qk_norm_epsilon,
+    double qk_norm_weight_bias) {
   CHECK_LAST_DIM_CONTIGUOUS(q);
   CHECK_LAST_DIM_CONTIGUOUS(k);
+  CHECK_LAST_DIM_CONTIGUOUS(q_rope);
+  CHECK_LAST_DIM_CONTIGUOUS(k_rope);
 
   const bool save_kv_cache = v.has_value();
   if (save_kv_cache) {
@@ -72,6 +75,8 @@ void apply_rope_pos_ids_cos_sin_cache_impl(
   CHECK_INPUT(pos_ids);
   auto device = q.device();
   CHECK_EQ(k.device(), device);
+  CHECK_EQ(q_rope.device(), device);
+  CHECK_EQ(k_rope.device(), device);
   CHECK_EQ(cos_sin_cache.device(), device);
   CHECK_EQ(pos_ids.device(), device);
   CHECK_DIM(3, q);  // q: (nnz, H_Q, D)
@@ -82,6 +87,11 @@ void apply_rope_pos_ids_cos_sin_cache_impl(
   CHECK_DIM(2, cos_sin_cache);
   CHECK_EQ(q.size(0), k.size(0));
   CHECK_EQ(q.size(2), k.size(2));
+  CHECK_EQ(q.sizes(), q_rope.sizes());
+  CHECK_EQ(k.sizes(), k_rope.sizes());
+  CHECK_EQ(q.scalar_type(), k.scalar_type());
+  CHECK_EQ(q.scalar_type(), q_rope.scalar_type());
+  CHECK_EQ(q.scalar_type(), k_rope.scalar_type());
   unsigned int rotary_dim = cos_sin_cache.size(1);
   unsigned int num_qo_heads = q.size(1);
   unsigned int num_kv_heads = k.size(1);
@@ -97,7 +107,17 @@ void apply_rope_pos_ids_cos_sin_cache_impl(
     CHECK_EQ(k_weight.scalar_type(), q.scalar_type());
     CHECK_EQ(q_weight.numel(), head_dim);
     CHECK_EQ(k_weight.numel(), head_dim);
-    CHECK_EQ(rotary_dim, head_dim);
+    CHECK_GE(head_dim, rotary_dim);
+    const unsigned int vec_size = std::max<unsigned int>(
+        16 / q.element_size(), head_dim / 32);
+    CHECK_EQ(rotary_dim % vec_size, 0);
+    if (!interleave) {
+      const unsigned int half_rotary_threads = rotary_dim / vec_size / 2;
+      TORCH_CHECK(
+          half_rotary_threads > 0 &&
+              (half_rotary_threads & (half_rotary_threads - 1)) == 0,
+          "NeoX partial rotary dimension must map to a power-of-two half warp");
+    }
   }
   size_t q_stride_n = q.stride(0);
   size_t q_stride_h = q.stride(1);
@@ -111,9 +131,7 @@ void apply_rope_pos_ids_cos_sin_cache_impl(
 
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(q.scalar_type(), c_type, [&] {
-    // TODO temporarily only use `BatchQKApplyRotaryPosIdsCosSinCacheEnhanced` when save_kv_cache
-    // to avoid changing original code path; but this branch is feature-complete and should switch to this later
-    if (save_kv_cache) {
+    if (save_kv_cache || apply_qk_norm) {
       cudaError_t status = BatchQKApplyRotaryPosIdsCosSinCacheEnhanced(
           static_cast<c_type*>(q.data_ptr()),
           static_cast<c_type*>(k.data_ptr()),
@@ -121,6 +139,7 @@ void apply_rope_pos_ids_cos_sin_cache_impl(
           apply_qk_norm ? static_cast<c_type*>(q_norm_weight->data_ptr()) : nullptr,
           apply_qk_norm ? static_cast<c_type*>(k_norm_weight->data_ptr()) : nullptr,
           static_cast<float>(qk_norm_epsilon),
+          static_cast<float>(qk_norm_weight_bias),
           static_cast<c_type*>(q_rope.data_ptr()),
           static_cast<c_type*>(k_rope.data_ptr()),
           save_kv_cache ? static_cast<c_type*>(k_buffer->data_ptr()) : nullptr,
@@ -205,7 +224,7 @@ void apply_rope_pos_ids_cos_sin_cache(
     const std::optional<at::Tensor>& kv_cache_loc) {
   apply_rope_pos_ids_cos_sin_cache_impl(
       q, k, q_rope, k_rope, cos_sin_cache, pos_ids, interleave, enable_pdl,
-      v, k_buffer, v_buffer, kv_cache_loc, nullptr, nullptr, 0.0);
+      v, k_buffer, v_buffer, kv_cache_loc, nullptr, nullptr, 0.0, 0.0);
 }
 
 void qk_norm_rope_and_cache(
@@ -224,5 +243,32 @@ void qk_norm_rope_and_cache(
   apply_rope_pos_ids_cos_sin_cache_impl(
       q, k, q, k, cos_sin_cache, pos_ids, interleave, false,
       v, k_buffer, v_buffer, kv_cache_loc,
-      &q_norm_weight, &k_norm_weight, epsilon);
+      &q_norm_weight, &k_norm_weight, epsilon, 0.0);
+}
+
+void gemma_qk_norm_rope(
+    at::Tensor q,
+    at::Tensor k,
+    at::Tensor v,
+    at::Tensor q_rope,
+    at::Tensor k_rope,
+    at::Tensor q_norm_weight,
+    at::Tensor k_norm_weight,
+    at::Tensor cos_sin_cache,
+    at::Tensor pos_ids,
+    const std::optional<at::Tensor>& k_buffer,
+    const std::optional<at::Tensor>& v_buffer,
+    const std::optional<at::Tensor>& kv_cache_loc,
+    double epsilon) {
+  const bool save_kv_cache = k_buffer.has_value();
+  TORCH_CHECK(
+      save_kv_cache == v_buffer.has_value() &&
+          save_kv_cache == kv_cache_loc.has_value(),
+      "K cache, V cache, and cache locations must be provided together");
+  const std::optional<at::Tensor> value =
+      save_kv_cache ? std::make_optional(v) : std::nullopt;
+  apply_rope_pos_ids_cos_sin_cache_impl(
+      q, k, q_rope, k_rope, cos_sin_cache, pos_ids, false, false,
+      value, k_buffer, v_buffer, kv_cache_loc,
+      &q_norm_weight, &k_norm_weight, epsilon, 1.0);
 }

--- a/sfkernels/include/ops.h
+++ b/sfkernels/include/ops.h
@@ -55,7 +55,13 @@ void build_tree_kernel_efficient(
 /*
  * From csrc/elementwise
  */
-void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double eps, at::optional<at::Tensor> input_2=at::nullopt);
+void rmsnorm(at::Tensor& output, at::Tensor& input, at::Tensor& weight, double eps, at::optional<at::Tensor> input_2=at::nullopt, bool gemma_style=false);
+void gated_rmsnorm(
+    at::Tensor& output,
+    const at::Tensor& input,
+    const at::Tensor& gate,
+    const at::Tensor& weight,
+    double eps);
 // void sgl_fused_add_rmsnorm(torch::Tensor input, torch::Tensor residual, torch::Tensor weight, double eps, bool enable_pdl);
 void silu_and_mul(at::Tensor& out, at::Tensor& input);
 void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input);
@@ -86,6 +92,21 @@ void qk_norm_rope_and_cache(
     at::Tensor v_buffer,
     at::Tensor kv_cache_loc,
     double epsilon);
+void gemma_qk_norm_rope(
+    at::Tensor q,
+    at::Tensor k,
+    at::Tensor v,
+    at::Tensor q_rope,
+    at::Tensor k_rope,
+    at::Tensor q_norm_weight,
+    at::Tensor k_norm_weight,
+    at::Tensor cos_sin_cache,
+    at::Tensor pos_ids,
+    const std::optional<at::Tensor>& k_buffer,
+    const std::optional<at::Tensor>& v_buffer,
+    const std::optional<at::Tensor>& kv_cache_loc,
+    double epsilon);
+void fused_sigmoid_mul(at::Tensor& output, const at::Tensor& gate);
 
 // quantization fp8 ops
 void sgl_per_tensor_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s, bool is_static);

--- a/sfkernels/pyproject.toml
+++ b/sfkernels/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["ninja", "setuptools>=61", "torch", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/sfkernels/python/sf_kernel/__init__.py
+++ b/sfkernels/python/sf_kernel/__init__.py
@@ -46,7 +46,17 @@ try:
     build_tree_kernel_efficient = torch.ops.sfkernels.build_tree_kernel_efficient
     verify_tree_greedy = torch.ops.sfkernels.verify_tree_greedy
     rmsnorm = torch.ops.sfkernels.rmsnorm
-    __all__ = ["build_tree_kernel_efficient", "verify_tree_greedy", "rmsnorm"]
+    gated_rmsnorm = torch.ops.sfkernels.gated_rmsnorm
+    gemma_qk_norm_rope = torch.ops.sfkernels.gemma_qk_norm_rope
+    fused_sigmoid_mul = torch.ops.sfkernels.fused_sigmoid_mul
+    __all__ = [
+        "build_tree_kernel_efficient",
+        "verify_tree_greedy",
+        "rmsnorm",
+        "gated_rmsnorm",
+        "gemma_qk_norm_rope",
+        "fused_sigmoid_mul",
+    ]
 except AttributeError:
     print("Warning: CUDA kernels not available. Functions may not be registered properly.")
     __all__ = []

--- a/sfkernels/tests/test_ops.py
+++ b/sfkernels/tests/test_ops.py
@@ -1,5 +1,6 @@
 import torch
 import pytest
+import math
 from sfllm.layers.activations import SiluAndMul, GeluAndMul
 from sfllm.layers.rotary_embedding import RotaryEmbedding
 
@@ -198,3 +199,24 @@ def test_qk_norm_rope_and_cache(dtype):
     torch.testing.assert_close(k, k_ref, atol=5e-2, rtol=1e-2)
     torch.testing.assert_close(k_cache[cache_locs], k)
     torch.testing.assert_close(v_cache[cache_locs], v_ref)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("shape", [
+    (24, 16, 256), (3, 128, 128), (3, 7, 127), (1, 1, 1),
+    (17, 3, 1025), (0, 7, 128), (3, 0, 128),
+    (3, 1), (3, 127), (3, 16384),
+])
+def test_sigmoid_mul_strided_gate(shape, dtype):
+    torch.manual_seed(0)
+    storage = torch.randn(*shape[:-1], 2 * shape[-1] + 1, device="cuda", dtype=dtype)
+    gate = storage[..., 1:shape[-1] + 1]
+    output = torch.randn(shape[0], math.prod(shape[1:]), device="cuda", dtype=dtype)
+    expected = (output.float() * gate.float().reshape_as(output).sigmoid()).to(dtype)
+
+    sf_kernel.fused_sigmoid_mul(output, gate)
+
+    torch.testing.assert_close(
+        output, expected, atol=1e-5,
+        rtol=1e-5 if dtype == torch.float32 else 1e-2,
+    )

--- a/sfkernels/tests/test_rmsnorm.py
+++ b/sfkernels/tests/test_rmsnorm.py
@@ -1,7 +1,8 @@
 import torch
 import pytest
 import sf_kernel
-from sfllm.layers.layernorm import RMSNorm
+from sfllm.layers.layernorm import GemmaRMSNorm, RMSNorm
+import sfllm.layers.layernorm as layernorm
 
 # Skip all tests in this module if CUDA is not available
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -70,9 +71,10 @@ def test_rmsnorm_fused(hidden_size, num_tokens, dtype):
     torch.testing.assert_close(residual_custom, residual_out_ref, atol=1e-2, rtol=1e-2)
 
 
+@pytest.mark.parametrize("gemma_style", [False, True])
 @pytest.mark.parametrize("with_residual", [False, True])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_rmsnorm_strided_qkv_view(with_residual, dtype):
+def test_rmsnorm_strided_qkv_view(with_residual, dtype, gemma_style):
     torch.manual_seed(0)
     num_tokens, num_heads, head_dim = 7, 32, 128
     q_size = num_heads * head_dim
@@ -95,13 +97,35 @@ def test_rmsnorm_strided_qkv_view(with_residual, dtype):
     expected = (
         values
         * torch.rsqrt(values.square().mean(dim=-1, keepdim=True) + 1e-6)
-        * weight.float()
+        * (weight.float() + float(gemma_style))
     ).to(dtype)
 
-    sf_kernel.rmsnorm(output, input_tensor, weight, 1e-6, residual)
+    sf_kernel.rmsnorm(output, input_tensor, weight, 1e-6, residual, gemma_style=gemma_style)
 
     torch.testing.assert_close(output, expected, atol=1e-2, rtol=1e-2)
     if residual is not None:
         torch.testing.assert_close(
             residual, values.to(dtype), atol=1e-2, rtol=1e-2
         )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("shape", [
+    (24, 32, 128), (1, 1, 1), (3, 7, 127), (3, 3, 129),
+    (3, 3, 1024), (3, 3, 1025), (3, 2, 4096),
+    (0, 3, 128), (3, 0, 128),
+])
+def test_gated_rmsnorm_strided(shape, dtype):
+    torch.manual_seed(0)
+    storage = torch.randn(*shape[:-1], 2 * shape[-1] + 1, device="cuda", dtype=dtype)
+    values = storage[..., 1:shape[-1] + 1]
+    gate = torch.randn_like(storage)[..., 1:shape[-1] + 1]
+    weight = torch.randn(shape[-1], device="cuda", dtype=torch.float32)
+    output = torch.empty(shape, device="cuda", dtype=dtype)
+    x, z = values.float(), gate.float()
+    expected = (x * torch.rsqrt(x.square().mean(-1, keepdim=True) + 1e-6)
+                * weight * z * z.sigmoid()).to(dtype)
+
+    sf_kernel.gated_rmsnorm(output, values, gate, weight, 1e-6)
+
+    torch.testing.assert_close(output, expected, atol=1e-3, rtol=1e-2)


### PR DESCRIPTION
Adds fused CUDA operations for Gemma QK normalization with partial RoPE and optional KV cache writes, RMSNorm with a SiLU gate, and sigmoid output gating. Extends RMSNorm with Gemma's `(1 + weight)` scale while keeping normalization arithmetic in FP32.

Also distributes SiLU work across tokens for small decode batches, reuses the shared conversion helpers, exports the new operators, and declares the extension's build dependencies. The change is confined to `sfkernels/`.

Validation: CUDA extension build succeeded on an NVIDIA H100 NVL. All 73 tests in `sfkernels/tests/test_ops.py` and `sfkernels/tests/test_rmsnorm.py` passed using an isolated checkout of this commit.
