### PR TITLE
feat: support Qwen3.5-4B

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,7 @@ Reproduce the Qwen3.5-4B benchmark with 1000 prompts, server concurrency 32, and
 
 ## Recorded environment and workload
 
-Reference run: 2026-09-07, Qwen3.5-4B, on the complete source before the two-PR split (source tree `bbdcb27d22f4f9a369952dd1943281abe5033f9f`). This includes both the model-support and engine/scheduling changes. The result is not a standalone measurement of PR 1 or a measured speedup from PR 1 to PR 2.
+The configuration below is being used for the standalone PR 1 benchmark. Its 1000-prompt result will be added after the run completes.
 
 | Setting | Value |
 | --- | --- |
@@ -73,7 +73,7 @@ export PYTHONPATH=/workspace/sfllm/python:/workspace/sfllm/sfkernels/python
 until curl --fail --silent --max-time 2 http://127.0.0.1:8081/health >/dev/null; do
   sleep 1
 done
-mkdir -p /tmp/sfllm-postfix-sharegpt.xhzhtkti
+mkdir -p /tmp/sfllm-pr1-sharegpt.0tfmxqsv
 /workspace/sglang/.venv/bin/python -m sfllm.serving.sgl_bench_seving \
   --backend sglang-native \
   --host 127.0.0.1 \
@@ -88,29 +88,10 @@ mkdir -p /tmp/sfllm-postfix-sharegpt.xhzhtkti
   --seed 1 \
   --warmup-requests 1 \
   --output-details \
-  --output-file /tmp/sfllm-postfix-sharegpt.xhzhtkti/results.jsonl \
+  --output-file /tmp/sfllm-pr1-sharegpt.0tfmxqsv/results.jsonl \
   --sharegpt-output-len 1024 \
   --disable-ignore-eos
 ```
 
 The client completes one warmup request before timing the 1000 measured requests. Wait for its final benchmark summary and successful exit. `--output-details` keeps per-request results in the JSONL output.
 
-## 1000-prompt result
-
-| Metric | Recorded value |
-| --- | ---: |
-| Successful requests | 1000 / 1000 |
-| Benchmark duration | 208.822081 s |
-| Input tokens | 318819 |
-| Output tokens (server reported) | 907163 |
-| Output throughput | **4344.190972 tok/s** |
-| Input throughput | 1526.749461 tok/s |
-| Request throughput | 4.788766 req/s |
-| Mean / P99 end-to-end latency | 4954.320379 / 5749.094537 ms |
-| Mean / P99 time to first token | 36.902708 / 228.935116 ms |
-| Mean / P99 time per output token | 5.431799 / 5.850073 ms |
-| Mean / median / P99 inter-token latency | 5.438638 / 5.094174 / 18.360982 ms |
-
-Output throughput is server-reported output tokens divided by measured duration. Retokenized output was 904851 tokens and is not used for the reported throughput.
-
-Original local artifacts: `/tmp/sfllm-postfix-sharegpt.xhzhtkti/{run.json,client-command.json,client.log,results.jsonl}`. Server log: `/tmp/sfllm-fixed-nsys.267_3r7s/restored-server.log`. The recorded throughput run had no profiler or diagnostic workload.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,97 +1,42 @@
-# ShareGPT serving benchmark
+# ShareGPT benchmark
 
-Reproduce the Qwen3.5-4B benchmark with 1000 prompts, server concurrency 32, and client concurrency 24.
+Hardware: **NVIDIA H100 NVL, BF16**. ShareGPT, server concurrency 32, client concurrency 24.
 
-## Recorded environment and workload
+| Successful requests | Input tokens | Output tokens | Duration | Output throughput |
+| ---: | ---: | ---: | ---: | ---: |
+| 1000/1000 | 318819 | 914531 | 218.924 s | **4177.39 tok/s** |
 
-Run Qwen3.5-4B with the following environment and workload.
+Measured on `54300bc`, 2026-09-07. Mean TTFT: 108.224 ms; mean TPOT: 5.542 ms.
 
-| Setting | Value |
-| --- | --- |
-| GPU | 1 × NVIDIA H100 NVL, 93.09 GiB visible memory |
-| Python / PyTorch / CUDA runtime | 3.12.3 / 2.13.0 / 13.0 |
-| Triton / Transformers / FlashInfer | 3.7.1 / 5.12.1 / 0.6.18 |
-| Model and tokenizer | Qwen3.5-4B, local path `/mnt/data/jicwen/work/Qwen3.5-4B` |
-| Precision / memory fraction | BF16 / 0.7 |
-| Full attention / GDN prefill / GDN decode | FA3 / FlashInfer / FlashInfer |
-| Server / client maximum concurrency | 32 / 24 |
-| CUDA graphs / CPU–GPU overlap | Enabled; graph maximum batch size 32 / enabled |
-| Server context limit | 8192 tokens |
-| Dataset | `ShareGPT_V3_unfiltered_cleaned_split.json` |
-| Measured requests / warmup requests | 1000 / 1 (warmup excluded from timing) |
-| Seed / request rate | 1 / unlimited (`inf`, client default) |
-| Output token cap / dataset context filter | 1024 / prompt tokens + 1024 ≤ 8192 |
-| Sampling / EOS | Temperature 0; EOS respected (`--disable-ignore-eos`) |
-| API / streaming / chat template | Native `/generate` / enabled / disabled |
-
-ShareGPT sampling uses the first prompt/response pair from conversations with at least two turns, shuffles with seed 1, and selects 1000 entries after length filtering. Inputs are plain prompts. The 1024-token setting is a cap; EOS can stop generation earlier.
-
-Dataset SHA256: `35f0e213ce091ed9b9af2a1f0755e9d39f9ccec34ab281cd4ca60d70f6479ba4` (672837942 bytes).
-Model `config.json` SHA256: `ddc63e1c717afa86c865bb5e01313d89d72bb53b97ad4a8a03ba8510c0621670`.
-Tokenizer `tokenizer_config.json` SHA256: `316230d6a809701f4db5ea8f8fc862bc3a6f3229c937c174e674ff3ca0a64ac8`.
-
-## Prepare the model and dataset
-
-Install sfllm and its CUDA kernels first; see the [repository installation instructions](../README.md#installation). The commands below use the benchmark machine's paths and Python environment. Substitute these paths for another machine. If the model or dataset is absent, download it before starting the server:
+Set the model and dataset paths in both terminals, from the repository root. Use a Python environment with sfllm and its CUDA kernels installed.
 
 ```bash
-hf download Qwen/Qwen3.5-4B --local-dir /mnt/data/jicwen/work/Qwen3.5-4B
-curl -fL https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json \
-  -o /mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json
-sha256sum /mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json
+export BENCH_MODEL=/path/to/Qwen3.5-4B
+export BENCH_DATASET=/path/to/ShareGPT_V3_unfiltered_cleaned_split.json
+export PYTHONPATH="$PWD/python:$PWD/sfkernels/python"
 ```
 
-## Start the server
-
-Run in the first terminal. These are the recorded server arguments:
+Start the server:
 
 ```bash
-cd /workspace/sfllm
-export PYTHONDONTWRITEBYTECODE=1
-export PYTHONPATH=/workspace/sfllm/python:/workspace/sfllm/sfkernels/python
-/workspace/sglang/.venv/bin/python python/sfllm/serving/app.py \
-  --model-path /mnt/data/jicwen/work/Qwen3.5-4B \
-  --port 8081 \
-  --dtype bfloat16 \
-  --max-running-requests 32 \
-  --cuda-graph-max-bs 32 \
-  --attention-backend fa3 \
-  --linear-attn-backend flashinfer \
-  --mem-fraction 0.7
+python python/sfllm/serving/app.py \
+  --model-path "$BENCH_MODEL" --port 8081 --dtype bfloat16 \
+  --max-running-requests 32 --cuda-graph-max-bs 32 \
+  --attention-backend fa3 --linear-attn-backend flashinfer --mem-fraction 0.7
 ```
 
-Wait for weight loading, CUDA graph capture, and `Application startup complete` before sending requests.
-
-## Run the client
-
-In a second terminal, wait for the health endpoint and then run the recorded client command. Create the result directory, or replace `--output-file` with a new result path. The client appends one record per run.
+Wait for `Application startup complete` and a successful health check, then run the client in the second terminal:
 
 ```bash
-cd /workspace/sfllm
-export PYTHONDONTWRITEBYTECODE=1
-export PYTHONPATH=/workspace/sfllm/python:/workspace/sfllm/sfkernels/python
-until curl --fail --silent --max-time 2 http://127.0.0.1:8081/health >/dev/null; do
-  sleep 1
-done
-mkdir -p /tmp/sfllm-pr1-sharegpt.0tfmxqsv
-/workspace/sglang/.venv/bin/python -m sfllm.serving.sgl_bench_seving \
-  --backend sglang-native \
-  --host 127.0.0.1 \
-  --port 8081 \
-  --model /mnt/data/jicwen/work/Qwen3.5-4B \
-  --tokenizer /mnt/data/jicwen/work/Qwen3.5-4B \
-  --dataset-name sharegpt \
-  --dataset-path /mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json \
-  --num-prompts 1000 \
-  --max-concurrency 24 \
-  --sharegpt-context-len 8192 \
-  --seed 1 \
-  --warmup-requests 1 \
-  --output-details \
-  --output-file /tmp/sfllm-pr1-sharegpt.0tfmxqsv/results.jsonl \
-  --sharegpt-output-len 1024 \
-  --disable-ignore-eos
+curl --fail http://127.0.0.1:8081/health
+python -m sfllm.serving.sgl_bench_seving \
+  --backend sglang-native --host 127.0.0.1 --port 8081 \
+  --model "$BENCH_MODEL" --tokenizer "$BENCH_MODEL" \
+  --dataset-name sharegpt --dataset-path "$BENCH_DATASET" \
+  --num-prompts 1000 --max-concurrency 24 \
+  --sharegpt-context-len 8192 --sharegpt-output-len 1024 \
+  --seed 1 --warmup-requests 1 --disable-ignore-eos \
+  --output-details --output-file /tmp/sharegpt-1000.jsonl
 ```
 
-The client completes one warmup request before timing the 1000 measured requests. Wait for its final benchmark summary and successful exit. `--output-details` keeps per-request results in the JSONL output.
-
+The client uses streaming and temperature 0, respects EOS, and excludes the warmup request from timing. Wait for the final summary; detailed results are saved in the JSONL file.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,116 @@
+# ShareGPT serving benchmark
+
+Reproduce the Qwen3.5-4B benchmark with 1000 prompts, server concurrency 32, and client concurrency 24.
+
+## Recorded environment and workload
+
+Reference run: 2026-09-07, Qwen3.5-4B, on the complete source before the two-PR split (source tree `bbdcb27d22f4f9a369952dd1943281abe5033f9f`). This includes both the model-support and engine/scheduling changes. The result is not a standalone measurement of PR 1 or a measured speedup from PR 1 to PR 2.
+
+| Setting | Value |
+| --- | --- |
+| GPU | 1 × NVIDIA H100 NVL, 93.09 GiB visible memory |
+| Python / PyTorch / CUDA runtime | 3.12.3 / 2.13.0 / 13.0 |
+| Triton / Transformers / FlashInfer | 3.7.1 / 5.12.1 / 0.6.18 |
+| Model and tokenizer | Qwen3.5-4B, local path `/mnt/data/jicwen/work/Qwen3.5-4B` |
+| Precision / memory fraction | BF16 / 0.7 |
+| Full attention / GDN prefill / GDN decode | FA3 / FlashInfer / FlashInfer |
+| Server / client maximum concurrency | 32 / 24 |
+| CUDA graphs / CPU–GPU overlap | Enabled; graph maximum batch size 32 / enabled |
+| Server context limit | 8192 tokens |
+| Dataset | `ShareGPT_V3_unfiltered_cleaned_split.json` |
+| Measured requests / warmup requests | 1000 / 1 (warmup excluded from timing) |
+| Seed / request rate | 1 / unlimited (`inf`, client default) |
+| Output token cap / dataset context filter | 1024 / prompt tokens + 1024 ≤ 8192 |
+| Sampling / EOS | Temperature 0; EOS respected (`--disable-ignore-eos`) |
+| API / streaming / chat template | Native `/generate` / enabled / disabled |
+
+ShareGPT sampling uses the first prompt/response pair from conversations with at least two turns, shuffles with seed 1, and selects 1000 entries after length filtering. Inputs are plain prompts. The 1024-token setting is a cap; EOS can stop generation earlier.
+
+Dataset SHA256: `35f0e213ce091ed9b9af2a1f0755e9d39f9ccec34ab281cd4ca60d70f6479ba4` (672837942 bytes).
+Model `config.json` SHA256: `ddc63e1c717afa86c865bb5e01313d89d72bb53b97ad4a8a03ba8510c0621670`.
+Tokenizer `tokenizer_config.json` SHA256: `316230d6a809701f4db5ea8f8fc862bc3a6f3229c937c174e674ff3ca0a64ac8`.
+
+## Prepare the model and dataset
+
+Install sfllm and its CUDA kernels first; see the [repository installation instructions](../README.md#installation). The commands below use the benchmark machine's paths and Python environment. Substitute these paths for another machine. If the model or dataset is absent, download it before starting the server:
+
+```bash
+hf download Qwen/Qwen3.5-4B --local-dir /mnt/data/jicwen/work/Qwen3.5-4B
+curl -fL https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json \
+  -o /mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json
+sha256sum /mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json
+```
+
+## Start the server
+
+Run in the first terminal. These are the recorded server arguments:
+
+```bash
+cd /workspace/sfllm
+export PYTHONDONTWRITEBYTECODE=1
+export PYTHONPATH=/workspace/sfllm/python:/workspace/sfllm/sfkernels/python
+/workspace/sglang/.venv/bin/python -m sfllm.serving.app \
+  --model-path /mnt/data/jicwen/work/Qwen3.5-4B \
+  --port 8081 \
+  --dtype bfloat16 \
+  --max-running-requests 32 \
+  --cuda-graph-max-bs 32 \
+  --attention-backend fa3 \
+  --linear-attn-backend flashinfer \
+  --mem-fraction 0.7
+```
+
+Wait for weight loading, CUDA graph capture, and `Application startup complete` before sending requests.
+
+## Run the client
+
+In a second terminal, wait for the health endpoint and then run the recorded client command. Create the result directory, or replace `--output-file` with a new result path. The client appends one record per run.
+
+```bash
+cd /workspace/sfllm
+export PYTHONDONTWRITEBYTECODE=1
+export PYTHONPATH=/workspace/sfllm/python:/workspace/sfllm/sfkernels/python
+until curl --fail --silent --max-time 2 http://127.0.0.1:8081/health >/dev/null; do
+  sleep 1
+done
+mkdir -p /tmp/sfllm-postfix-sharegpt.xhzhtkti
+/workspace/sglang/.venv/bin/python -m sfllm.serving.sgl_bench_seving \
+  --backend sglang-native \
+  --host 127.0.0.1 \
+  --port 8081 \
+  --model /mnt/data/jicwen/work/Qwen3.5-4B \
+  --tokenizer /mnt/data/jicwen/work/Qwen3.5-4B \
+  --dataset-name sharegpt \
+  --dataset-path /mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json \
+  --num-prompts 1000 \
+  --max-concurrency 24 \
+  --sharegpt-context-len 8192 \
+  --seed 1 \
+  --warmup-requests 1 \
+  --output-details \
+  --output-file /tmp/sfllm-postfix-sharegpt.xhzhtkti/results.jsonl \
+  --sharegpt-output-len 1024 \
+  --disable-ignore-eos
+```
+
+The client completes one warmup request before timing the 1000 measured requests. Wait for its final benchmark summary and successful exit. `--output-details` keeps per-request results in the JSONL output.
+
+## 1000-prompt result
+
+| Metric | Recorded value |
+| --- | ---: |
+| Successful requests | 1000 / 1000 |
+| Benchmark duration | 208.822081 s |
+| Input tokens | 318819 |
+| Output tokens (server reported) | 907163 |
+| Output throughput | **4344.190972 tok/s** |
+| Input throughput | 1526.749461 tok/s |
+| Request throughput | 4.788766 req/s |
+| Mean / P99 end-to-end latency | 4954.320379 / 5749.094537 ms |
+| Mean / P99 time to first token | 36.902708 / 228.935116 ms |
+| Mean / P99 time per output token | 5.431799 / 5.850073 ms |
+| Mean / median / P99 inter-token latency | 5.438638 / 5.094174 / 18.360982 ms |
+
+Output throughput is server-reported output tokens divided by measured duration. Retokenized output was 904851 tokens and is not used for the reported throughput.
+
+Original local artifacts: `/tmp/sfllm-postfix-sharegpt.xhzhtkti/{run.json,client-command.json,client.log,results.jsonl}`. Server log: `/tmp/sfllm-fixed-nsys.267_3r7s/restored-server.log`. The recorded throughput run had no profiler or diagnostic workload.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,7 @@ Reproduce the Qwen3.5-4B benchmark with 1000 prompts, server concurrency 32, and
 
 ## Recorded environment and workload
 
-The configuration below is being used for the standalone PR 1 benchmark. Its 1000-prompt result will be added after the run completes.
+Run Qwen3.5-4B with the following environment and workload.
 
 | Setting | Value |
 | --- | --- |
@@ -49,7 +49,7 @@ Run in the first terminal. These are the recorded server arguments:
 cd /workspace/sfllm
 export PYTHONDONTWRITEBYTECODE=1
 export PYTHONPATH=/workspace/sfllm/python:/workspace/sfllm/sfkernels/python
-/workspace/sglang/.venv/bin/python -m sfllm.serving.app \
+/workspace/sglang/.venv/bin/python python/sfllm/serving/app.py \
   --model-path /mnt/data/jicwen/work/Qwen3.5-4B \
   --port 8081 \
   --dtype bfloat16 \

--- a/python/sfllm/engine/memory_pool.py
+++ b/python/sfllm/engine/memory_pool.py
@@ -4,6 +4,7 @@ import logging
 import itertools
 import torch
 from typing import List
+from sfllm.model_loader.model_config import get_pool_index_layers
 from sfllm.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -39,7 +40,7 @@ class BlockMemoryManager:
             dtype if server_args.dtype == "auto" else getattr(torch, server_args.dtype)
         )
         self.config = model_config
-
+        self.pool_index_layers = get_pool_index_layers(model_config)
         self.num_blocks = num_blocks
         self.num_blocks, self.block_shape = self.get_num_blocks(server_args)
         self.blocks = [BlockMemory(i) for i in range(self.num_blocks)]
@@ -47,7 +48,7 @@ class BlockMemoryManager:
         self.release_block_ids = []
         self.used_block_ids = set([])
         self.kv_buffers = []
-        self.create_physical_memory_pool(server_args)
+        self.create_physical_memory_pool()
 
     def get_num_blocks(self, server_args) -> int:
         config = self.config
@@ -61,7 +62,7 @@ class BlockMemoryManager:
         max_length = (
             int(free * server_args.mem_fraction)
             // one_token_size
-            // config.num_hidden_layers
+            // len(self.pool_index_layers)
         )
         if self.num_blocks is not None:
             max_length = min(max_length, self.num_blocks)
@@ -71,22 +72,15 @@ class BlockMemoryManager:
         )
         return max_length, (n_heads, dim)
 
-    def create_physical_memory_pool(self, server_args):
-        config = self.config
+    def create_physical_memory_pool(self):
+        num_pool_layers = len(self.pool_index_layers)
         kv_buffers = (
-                torch.zeros((config.num_hidden_layers,
-                    self.num_blocks, *self.block_shape), dtype=self.dtype, device="cuda"
-                ),
-                torch.zeros((config.num_hidden_layers,
-                    self.num_blocks, *self.block_shape), dtype=self.dtype, device="cuda"),
+            torch.zeros((num_pool_layers, self.num_blocks, *self.block_shape),
+                dtype=self.dtype, device="cuda"),
+            torch.zeros((num_pool_layers, self.num_blocks, *self.block_shape),
+                dtype=self.dtype, device="cuda"),
         )
-        for _ in range(config.num_hidden_layers):
-            self.kv_buffers.append(
-                (
-                    kv_buffers[0][_],
-                    kv_buffers[1][_],
-                )
-            )
+        self.kv_buffers.extend(zip(kv_buffers[0], kv_buffers[1]))
 
     def _alloc_block_by_id(self, block_id: int, token_id: int, hashv: int) -> BlockMemory:
         """Allocate a block of memory by block ID."""

--- a/python/sfllm/engine/model_worker.py
+++ b/python/sfllm/engine/model_worker.py
@@ -1,6 +1,7 @@
 import logging
 from sfllm.engine.schedule_batch import ScheduleBatch,BatchResult
 from sfllm.engine.model_runner import ModelRunner
+from sfllm.models.interfaces import HasBatchState
 from sfllm.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -25,4 +26,7 @@ class ModelWorker:
         self.model_runner.init_capture_cudagraph()
 
     def forward(self, scheduled_batch: ScheduleBatch) -> BatchResult:
+        model = self.model_runner.model
+        if isinstance(model, HasBatchState):
+            model.prepare_batch_state(scheduled_batch)
         return self.model_runner.forward(scheduled_batch)

--- a/python/sfllm/engine/sampling_params.py
+++ b/python/sfllm/engine/sampling_params.py
@@ -2,12 +2,27 @@
 from typing import Dict, Any
 
 class SamplingParams:
-    def __init__(self, max_new_tokens=50, temperature=0.8, top_p=0.95, top_k=1073741824):
+    def __init__(
+        self,
+        max_new_tokens=50,
+        temperature=0.8,
+        top_p=0.95,
+        top_k=1073741824,
+        stop_token_ids=None,
+        stop=None,
+    ):
         self.max_new_tokens = max_new_tokens
         self.temperature = temperature
         self.top_p = top_p
         self.top_k = top_k
-        self.is_greedy = top_k <=1
+        if isinstance(stop_token_ids, int):
+            stop_token_ids = (stop_token_ids,)
+        self.stop_token_ids = frozenset(stop_token_ids or ())
+        if isinstance(stop, str):
+            stop = (stop,)
+        self.stop = tuple(stop or ())
+        self.stop_token_sequences = ()
+        self.is_greedy = temperature == 0 or top_k <= 1
 
     @classmethod
     def from_dict(cls, params: Dict[str, Any]) -> "SamplingParams":
@@ -16,4 +31,6 @@ class SamplingParams:
             temperature=params.get("temperature", 0.8),
             top_p=params.get("top_p", 0.95),
             top_k=params.get("top_k", 1073741824),
+            stop_token_ids=params.get("stop_token_ids"),
+            stop=params.get("stop"),
         )

--- a/python/sfllm/engine/scheduler.py
+++ b/python/sfllm/engine/scheduler.py
@@ -1,6 +1,7 @@
 import time
 import queue
 import logging
+from collections import deque
 from typing import List, Tuple
 
 
@@ -53,7 +54,9 @@ class Scheduler:
         
         self.max_context_length = server_args.max_context_length
         self.max_prefill_tokens = min(self.max_context_length, 8192)
-        self.max_running_req = server_args.cuda_graph_max_bs
+        self.max_running_req = server_args.max_running_requests
+        # Stable slots are shared by overlap token handoff and model-owned state.
+        self.free_request_indices = deque(range(self.max_running_req))
         self.abort_requests = set()
 
         self.server_args = server_args
@@ -90,8 +93,7 @@ class Scheduler:
         # schedule prefill first
         prefill_tokens = 0
 
-        overlap_running_size = self.max_running_req
-        while not self.waiting_queue.empty():
+        while not self.waiting_queue.empty() and self.free_request_indices:
             # check abort requests first
             if self.waiting_queue.queue[0].sequence_id in self.abort_requests:
                 sequence = self.waiting_queue.get()
@@ -105,6 +107,8 @@ class Scheduler:
                 break
             assert self.mem_pool.can_alloc(len(tokens))
             sequence = self.waiting_queue.get()
+            assert sequence.request_index == -1
+            sequence.request_index = self.free_request_indices.popleft()
             sequence.status = SequenceStatus.RUNNING
             self.scheduler_policy.add_prefill_req(sequence)
             running_sequences.append(sequence)
@@ -142,7 +146,7 @@ class Scheduler:
                 self.flying_batch = ScheduleBatch([], self.mem_pool)
         # if there is no prefill request, schedule decode requests
         elif len(running_sequences) == 0: # no overlap
-            while not self.running_queue.empty() and len(running_sequences) < overlap_running_size:
+            while not self.running_queue.empty() and len(running_sequences) < self.max_running_req:
                 if self.running_queue.queue[0].sequence_id in self.abort_requests:
                     sequence = self.running_queue.get()
                     self.free_sequence_resources(sequence)
@@ -199,6 +203,9 @@ class Scheduler:
             self.scheduler_policy.release_req(sequence)
         if sequence.out_cache_loc_spec:
             self.draft_memory_pool.free_block(sequence.out_cache_loc_spec)
+        if sequence.request_index >= 0:
+            self.free_request_indices.append(sequence.request_index)
+            sequence.request_index = -1
 
     def is_done(self) -> bool:
         return self.waiting_queue.empty() and self.running_queue.empty()

--- a/python/sfllm/engine/sequence.py
+++ b/python/sfllm/engine/sequence.py
@@ -103,11 +103,22 @@ class RequestSequence(RawSequence):
         self.last_generated_token_pos = self.prompt_token_len
     
     def is_done(self) -> bool:
-        return (
+        generated_count = self.last_generated_token_pos - self.prompt_token_len
+        if (
             not self.status.is_active()
-            or self.last_generated_token_pos - self.prompt_token_len
-            >= self.sampling_params.max_new_tokens
-        )
+            or generated_count >= self.sampling_params.max_new_tokens
+            or not self.sampling_params.stop_token_ids.isdisjoint(
+                self.generated_tokens
+            )
+        ):
+            return True
+        for stop in self.sampling_params.stop_token_sequences:
+            if len(stop) > generated_count:
+                continue
+            start = self.last_generated_token_pos - len(stop)
+            if tuple(self.tokens[start : self.last_generated_token_pos]) == stop:
+                return True
+        return False
 
     def export_raw_sequence(self) -> RawSequence:
         return RawSequence(

--- a/python/sfllm/engine/sequence.py
+++ b/python/sfllm/engine/sequence.py
@@ -78,6 +78,7 @@ class RequestSequence(RawSequence):
         self.out_cache_loc_spec = []
         self.out_cache_loc_lazy = None # tensor on cuda
         self.marked = False # marked for draft token handling, fill with -1 for the future accepted tokens
+        self.request_index = -1
         if input_ids is not None:
             self.tokens = input_ids
             self.prompt_token_len = len(input_ids)

--- a/python/sfllm/kernels/gdn.py
+++ b/python/sfllm/kernels/gdn.py
@@ -1,0 +1,805 @@
+"""Gated DeltaNet backends and fused preprocessing kernels for Qwen3.5."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+import sf_kernel
+
+def _load_gdn_kernels(prefill_backend: str, decode_backend: str):
+    try:
+        from sgl_kernel import causal_conv1d_fwd
+    except ImportError as exc:
+        raise ImportError(
+            "Qwen3.5 requires sgl-kernel with the causal-conv1d operators"
+        ) from exc
+    chunk_gated_delta_rule = None
+    gated_delta_rule_decode_pretranspose = None
+    if prefill_backend == "flashinfer":
+        from flashinfer.gdn_prefill import chunk_gated_delta_rule
+    if decode_backend == "flashinfer":
+        from flashinfer.gdn_decode import gated_delta_rule_decode_pretranspose
+    return (
+        causal_conv1d_fwd,
+        chunk_gated_delta_rule,
+        gated_delta_rule_decode_pretranspose,
+    )
+
+
+@triton.jit(
+    do_not_specialize=["num_tokens", "stride_dim"],
+    do_not_specialize_on_alignment=["num_tokens", "stride_dim"],
+)
+def _split_l2norm_qkv_gates_kernel(
+    mixed_qkv,
+    q,
+    k,
+    v,
+    g,
+    beta,
+    a,
+    b,
+    a_log,
+    dt_bias,
+    stride_token,
+    stride_dim,
+    stride_a_token,
+    stride_a_head,
+    stride_b_token,
+    stride_b_head,
+    num_tokens,
+    num_k_heads: tl.constexpr,
+    num_v_heads: tl.constexpr,
+    head_k_dim: tl.constexpr,
+    head_v_dim: tl.constexpr,
+    block_t: tl.constexpr,
+    block_k: tl.constexpr,
+    block_v: tl.constexpr,
+):
+    token = tl.program_id(0) * block_t + tl.arange(0, block_t)
+    head = tl.program_id(1)
+    token_mask = token < num_tokens
+
+    kd = tl.arange(0, block_k)
+    key_mask = (head < num_k_heads) & (kd[:, None] < head_k_dim)
+    key_mask &= token_mask[None, :]
+    q_offset = head * head_k_dim + kd[:, None]
+    q_value = tl.load(
+        mixed_qkv + q_offset * stride_dim + token[None, :] * stride_token,
+        mask=key_mask,
+        other=0.0,
+    ).to(tl.float32)
+    q_value *= tl.rsqrt(tl.sum(q_value * q_value, axis=0)[None, :] + 1e-6)
+    tl.store(
+        q + token[:, None] * (num_k_heads * head_k_dim) + q_offset.trans(),
+        q_value.trans(),
+        mask=key_mask.trans(),
+    )
+
+    k_offset = num_k_heads * head_k_dim + q_offset
+    k_value = tl.load(
+        mixed_qkv + k_offset * stride_dim + token[None, :] * stride_token,
+        mask=key_mask,
+        other=0.0,
+    ).to(tl.float32)
+    k_value *= tl.rsqrt(tl.sum(k_value * k_value, axis=0)[None, :] + 1e-6)
+    tl.store(
+        k + token[:, None] * (num_k_heads * head_k_dim) + q_offset.trans(),
+        k_value.trans(),
+        mask=key_mask.trans(),
+    )
+
+    vd = tl.arange(0, block_v)
+    value_mask = (head < num_v_heads) & (vd[:, None] < head_v_dim)
+    value_mask &= token_mask[None, :]
+    v_head_offset = head * head_v_dim + vd[:, None]
+    v_offset = 2 * num_k_heads * head_k_dim + v_head_offset
+    v_value = tl.load(
+        mixed_qkv + v_offset * stride_dim + token[None, :] * stride_token,
+        mask=value_mask,
+        other=0.0,
+    )
+    tl.store(
+        v
+        + token[:, None] * (num_v_heads * head_v_dim)
+        + v_head_offset.trans(),
+        v_value.trans(),
+        mask=value_mask.trans(),
+    )
+
+    gate_mask = token_mask & (head < num_v_heads)
+    a_value = tl.load(
+        a + token * stride_a_token + head * stride_a_head,
+        mask=gate_mask,
+        other=0.0,
+    ).to(tl.float32)
+    b_value = tl.load(
+        b + token * stride_b_token + head * stride_b_head,
+        mask=gate_mask,
+        other=0.0,
+    ).to(tl.float32)
+    head_mask = head < num_v_heads
+    decay = tl.load(a_log + head, mask=head_mask, other=0.0).to(tl.float32)
+    bias = tl.load(dt_bias + head, mask=head_mask, other=0.0).to(tl.float32)
+    softplus_input = a_value + bias
+    softplus = tl.where(
+        softplus_input <= 20.0,
+        tl.log(1.0 + tl.exp(softplus_input)),
+        softplus_input,
+    )
+    gate_offset = token * num_v_heads + head
+    tl.store(g + gate_offset, tl.exp(-tl.exp(decay) * softplus), mask=gate_mask)
+    beta_value = tl.sigmoid(b_value).to(b.dtype.element_ty)
+    tl.store(beta + gate_offset, beta_value, mask=gate_mask)
+
+
+def split_l2norm_qkv_gates(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Prepare contiguous normalized QKV and GDN gates in one launch."""
+    num_tokens = mixed_qkv.shape[0]
+    q = mixed_qkv.new_empty((num_tokens, num_k_heads, head_k_dim))
+    k = torch.empty_like(q)
+    v = mixed_qkv.new_empty((num_tokens, num_v_heads, head_v_dim))
+    g = torch.empty_like(a, dtype=torch.float32)
+    beta = torch.empty_like(b, dtype=torch.float32)
+    block_t = 16
+    grid = (triton.cdiv(num_tokens, block_t), max(num_k_heads, num_v_heads))
+    _split_l2norm_qkv_gates_kernel[grid](
+        mixed_qkv,
+        q,
+        k,
+        v,
+        g,
+        beta,
+        a,
+        b,
+        a_log,
+        dt_bias,
+        mixed_qkv.stride(0),
+        mixed_qkv.stride(1),
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        num_tokens,
+        num_k_heads=num_k_heads,
+        num_v_heads=num_v_heads,
+        head_k_dim=head_k_dim,
+        head_v_dim=head_v_dim,
+        block_t=block_t,
+        block_k=triton.next_power_of_2(head_k_dim),
+        block_v=triton.next_power_of_2(head_v_dim),
+        num_warps=2,
+        num_stages=3,
+    )
+    return q, k, v, g, beta
+
+
+@triton.jit
+def _scatter_recurrent_state_kernel(
+    source,
+    destination,
+    state_indices,
+    stride_source,
+    stride_destination,
+    state_elements: tl.constexpr,
+    num_state_slots: tl.constexpr,
+    block: tl.constexpr,
+):
+    batch = tl.program_id(0)
+    offsets = tl.program_id(1) * block + tl.arange(0, block)
+    slot = tl.load(state_indices + batch).to(tl.int64)
+    mask = (offsets < state_elements) & (slot >= 0) & (slot < num_state_slots)
+    value = tl.load(
+        source + batch * stride_source + offsets,
+        mask=mask,
+        other=0.0,
+    )
+    tl.store(
+        destination + slot * stride_destination + offsets,
+        value,
+        mask=mask,
+    )
+
+
+def scatter_recurrent_state(
+    source: torch.Tensor,
+    destination: torch.Tensor,
+    state_indices: torch.Tensor,
+) -> None:
+    """Cast and scatter packed final states into model-local state rows."""
+    state_elements = source[0].numel()
+    block = 1024
+    _scatter_recurrent_state_kernel[
+        (source.shape[0], triton.cdiv(state_elements, block))
+    ](
+        source,
+        destination,
+        state_indices,
+        source.stride(0),
+        destination.stride(0),
+        state_elements=state_elements,
+        num_state_slots=destination.shape[0],
+        block=block,
+        num_warps=4,
+    )
+
+
+def gated_rmsnorm(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """RMSNorm followed by a SiLU output gate, fused into one launch."""
+    out = torch.empty(x.shape, dtype=x.dtype, device=x.device)
+    sf_kernel.gated_rmsnorm(out, x, gate, weight, eps)
+    return out
+
+
+@triton.jit
+def _fused_qkvzba_conv_decode_kernel(
+    mixed_qkv,
+    z,
+    b,
+    a,
+    projected_qkvz,
+    projected_ba,
+    conv_states,
+    conv_weight,
+    state_indices,
+    stride_qkvz,
+    stride_ba,
+    stride_state,
+    stride_state_dim,
+    stride_state_pos,
+    stride_weight_dim,
+    stride_indices,
+    qkv_dim: tl.constexpr,
+    value_dim: tl.constexpr,
+    num_v_heads: tl.constexpr,
+    num_state_slots: tl.constexpr,
+    kernel_width: tl.constexpr,
+    block: tl.constexpr,
+):
+    batch = tl.program_id(0)
+    offsets = tl.program_id(1) * block + tl.arange(0, block)
+    qkv_mask = offsets < qkv_dim
+    x = tl.load(
+        projected_qkvz + batch * stride_qkvz + offsets,
+        mask=qkv_mask,
+        other=0.0,
+    )
+
+    slot = tl.load(state_indices + batch * stride_indices).to(tl.int64)
+    valid_slot = (slot > 0) & (slot < num_state_slots)
+    state = conv_states + slot * stride_state + offsets * stride_state_dim
+    acc = tl.zeros((block,), dtype=tl.float32)
+    for pos in tl.static_range(kernel_width - 1):
+        state_value = tl.load(
+            state + pos * stride_state_pos,
+            mask=qkv_mask & valid_slot,
+            other=0.0,
+        )
+        weight_value = tl.load(
+            conv_weight + offsets * stride_weight_dim + pos,
+            mask=qkv_mask,
+            other=0.0,
+        )
+        acc += state_value * weight_value
+    last_weight = tl.load(
+        conv_weight + offsets * stride_weight_dim + kernel_width - 1,
+        mask=qkv_mask,
+        other=0.0,
+    )
+    acc += x * last_weight
+    conv_out = acc / (1.0 + tl.exp(-acc))
+    tl.store(
+        mixed_qkv + batch * qkv_dim + offsets,
+        tl.where(valid_slot, conv_out, x),
+        mask=qkv_mask,
+    )
+
+    for pos in tl.static_range(kernel_width - 2):
+        next_value = tl.load(
+            state + (pos + 1) * stride_state_pos,
+            mask=qkv_mask & valid_slot,
+            other=0.0,
+        )
+        tl.store(
+            state + pos * stride_state_pos,
+            next_value,
+            mask=qkv_mask & valid_slot,
+        )
+    tl.store(
+        state + (kernel_width - 2) * stride_state_pos,
+        x,
+        mask=qkv_mask & valid_slot,
+    )
+
+    z_mask = offsets < value_dim
+    z_value = tl.load(
+        projected_qkvz + batch * stride_qkvz + qkv_dim + offsets,
+        mask=z_mask,
+        other=0.0,
+    )
+    tl.store(z + batch * value_dim + offsets, z_value, mask=z_mask)
+
+    gate_mask = offsets < num_v_heads
+    tl.store(
+        b + batch * num_v_heads + offsets,
+        tl.load(
+            projected_ba + batch * stride_ba + offsets,
+            mask=gate_mask,
+            other=0.0,
+        ),
+        mask=gate_mask,
+    )
+    tl.store(
+        a + batch * num_v_heads + offsets,
+        tl.load(
+            projected_ba + batch * stride_ba + num_v_heads + offsets,
+            mask=gate_mask,
+            other=0.0,
+        ),
+        mask=gate_mask,
+    )
+
+
+def fused_qkvzba_conv_decode(
+    projected_qkvz: torch.Tensor,
+    projected_ba: torch.Tensor,
+    conv_states: torch.Tensor,
+    conv_weight: torch.Tensor,
+    state_indices: torch.Tensor,
+    num_v_heads: int,
+    head_v_dim: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fuse QKVZ/BA unpacking with indexed causal-Conv1D decode."""
+    batch = projected_qkvz.shape[0]
+    value_dim = num_v_heads * head_v_dim
+    qkv_dim = projected_qkvz.shape[1] - value_dim
+    mixed_qkv = torch.empty(
+        (batch, qkv_dim), dtype=projected_qkvz.dtype, device=projected_qkvz.device
+    )
+    z = torch.empty(
+        (batch, num_v_heads, head_v_dim),
+        dtype=projected_qkvz.dtype,
+        device=projected_qkvz.device,
+    )
+    b = torch.empty(
+        (batch, num_v_heads), dtype=projected_ba.dtype, device=projected_ba.device
+    )
+    a = torch.empty_like(b)
+    block = 256
+    _fused_qkvzba_conv_decode_kernel[
+        (batch, triton.cdiv(qkv_dim, block))
+    ](
+        mixed_qkv,
+        z,
+        b,
+        a,
+        projected_qkvz,
+        projected_ba,
+        conv_states,
+        conv_weight,
+        state_indices,
+        projected_qkvz.stride(0),
+        projected_ba.stride(0),
+        conv_states.stride(0),
+        conv_states.stride(1),
+        conv_states.stride(2),
+        conv_weight.stride(0),
+        state_indices.stride(0),
+        qkv_dim=qkv_dim,
+        value_dim=value_dim,
+        num_v_heads=num_v_heads,
+        num_state_slots=conv_states.shape[0],
+        kernel_width=conv_weight.shape[1],
+        block=block,
+        num_warps=8,
+        num_stages=2,
+    )
+    return mixed_qkv, z, b, a
+
+
+# Adapted from SGLang/FLA's packed recurrent GDN decode kernel.  Keeping the
+# packed QKV input avoids three materialization kernels in every GDN layer.
+@triton.jit
+def _packed_gdn_decode_kernel(
+    mixed_qkv,
+    a,
+    b,
+    a_log,
+    dt_bias,
+    output,
+    states,
+    state_indices,
+    stride_qkv,
+    stride_a,
+    stride_b,
+    stride_state,
+    stride_indices,
+    scale,
+    num_k_heads: tl.constexpr,
+    num_v_heads: tl.constexpr,
+    head_k_dim: tl.constexpr,
+    head_v_dim: tl.constexpr,
+    block_k: tl.constexpr,
+    block_v: tl.constexpr,
+):
+    value_tile = tl.program_id(0)
+    batch_head = tl.program_id(1)
+    batch = batch_head // num_v_heads
+    value_head = batch_head % num_v_heads
+    key_head = value_head // (num_v_heads // num_k_heads)
+
+    key_offsets = tl.arange(0, block_k)
+    value_offsets = value_tile * block_v + tl.arange(0, block_v)
+    key_mask = key_offsets < head_k_dim
+    value_mask = value_offsets < head_v_dim
+    state_mask = value_mask[:, None] & key_mask[None, :]
+
+    slot = tl.load(state_indices + batch * stride_indices).to(tl.int64)
+    output_ptr = output + (batch * num_v_heads + value_head) * head_v_dim
+    if slot <= 0:
+        tl.store(output_ptr + value_offsets, 0.0, mask=value_mask)
+        return
+
+    state_ptr = states + slot * stride_state
+    state_ptr += (
+        value_head * head_v_dim * head_k_dim
+        + value_offsets[:, None] * head_k_dim
+        + key_offsets[None, :]
+    )
+    state = tl.load(state_ptr, mask=state_mask, other=0.0).to(tl.float32)
+
+    qkv_ptr = mixed_qkv + batch * stride_qkv
+    q = tl.load(
+        qkv_ptr + key_head * head_k_dim + key_offsets,
+        mask=key_mask,
+        other=0.0,
+    ).to(tl.float32)
+    k = tl.load(
+        qkv_ptr + num_k_heads * head_k_dim + key_head * head_k_dim + key_offsets,
+        mask=key_mask,
+        other=0.0,
+    ).to(tl.float32)
+    v = tl.load(
+        qkv_ptr
+        + 2 * num_k_heads * head_k_dim
+        + value_head * head_v_dim
+        + value_offsets,
+        mask=value_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    q *= tl.rsqrt(tl.sum(q * q, axis=0) + 1e-6) * scale
+    k *= tl.rsqrt(tl.sum(k * k, axis=0) + 1e-6)
+    gate_a = tl.load(a + batch * stride_a + value_head).to(tl.float32)
+    gate_b = tl.load(b + batch * stride_b + value_head).to(tl.float32)
+    decay_log = tl.load(a_log + value_head).to(tl.float32)
+    bias = tl.load(dt_bias + value_head).to(tl.float32)
+    softplus_arg = gate_a + bias
+    softplus = tl.where(
+        softplus_arg <= 20.0,
+        tl.log(1.0 + tl.exp(softplus_arg)),
+        softplus_arg,
+    )
+    state *= tl.exp(-tl.exp(decay_log) * softplus)
+    prediction = tl.sum(state * k[None, :], axis=1)
+    correction = (v - prediction) * tl.sigmoid(gate_b)
+    state += correction[:, None] * k[None, :]
+    result = tl.sum(state * q[None, :], axis=1)
+    tl.store(output_ptr + value_offsets, result, mask=value_mask)
+    tl.store(state_ptr, state, mask=state_mask)
+
+
+def packed_gdn_decode(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    states: torch.Tensor,
+    state_indices: torch.Tensor,
+    num_k_heads: int,
+) -> torch.Tensor:
+    batch = mixed_qkv.shape[0]
+    num_v_heads, head_v_dim, head_k_dim = states.shape[-3:]
+    output = torch.empty(
+        (batch, num_v_heads, head_v_dim),
+        dtype=mixed_qkv.dtype,
+        device=mixed_qkv.device,
+    )
+    block_k = triton.next_power_of_2(head_k_dim)
+    block_v = min(triton.next_power_of_2(head_v_dim), 32)
+    _packed_gdn_decode_kernel[(triton.cdiv(head_v_dim, block_v), batch * num_v_heads)](
+        mixed_qkv,
+        a,
+        b,
+        a_log,
+        dt_bias,
+        output,
+        states,
+        state_indices,
+        mixed_qkv.stride(0),
+        a.stride(0),
+        b.stride(0),
+        states.stride(0),
+        state_indices.stride(0),
+        head_k_dim**-0.5,
+        num_k_heads=num_k_heads,
+        num_v_heads=num_v_heads,
+        head_k_dim=head_k_dim,
+        head_v_dim=head_v_dim,
+        block_k=block_k,
+        block_v=block_v,
+        num_warps=1,
+        num_stages=3,
+    )
+    return output
+
+
+@triton.jit
+def _packed_gdn_prefill_kernel(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    output,
+    states,
+    state_indices,
+    cu_seqlens,
+    stride_state,
+    scale,
+    num_k_heads: tl.constexpr,
+    num_v_heads: tl.constexpr,
+    head_k_dim: tl.constexpr,
+    head_v_dim: tl.constexpr,
+    block_k: tl.constexpr,
+    block_v: tl.constexpr,
+):
+    value_tile = tl.program_id(0)
+    seq_head = tl.program_id(1)
+    seq = seq_head // num_v_heads
+    value_head = seq_head % num_v_heads
+    key_head = value_head // (num_v_heads // num_k_heads)
+    begin = tl.load(cu_seqlens + seq).to(tl.int64)
+    end = tl.load(cu_seqlens + seq + 1).to(tl.int64)
+    slot = tl.load(state_indices + seq).to(tl.int64)
+
+    ko = tl.arange(0, block_k)
+    vo = value_tile * block_v + tl.arange(0, block_v)
+    km = ko < head_k_dim
+    vm = vo < head_v_dim
+    sm = vm[:, None] & km[None, :]
+    state_ptr = states + slot * stride_state
+    state_ptr += (
+        value_head * head_v_dim * head_k_dim
+        + vo[:, None] * head_k_dim
+        + ko[None, :]
+    )
+    state = tl.zeros((block_v, block_k), dtype=tl.float32)
+
+    token = begin
+    while token < end:
+        q_ptr = q + (token * num_k_heads + key_head) * head_k_dim
+        k_ptr = k + (token * num_k_heads + key_head) * head_k_dim
+        v_ptr = v + (token * num_v_heads + value_head) * head_v_dim
+        qv = tl.load(q_ptr + ko, mask=km, other=0.0).to(tl.float32) * scale
+        kv = tl.load(k_ptr + ko, mask=km, other=0.0).to(tl.float32)
+        vv = tl.load(v_ptr + vo, mask=vm, other=0.0).to(tl.float32)
+        state *= tl.load(g + token * num_v_heads + value_head).to(tl.float32)
+        vv -= tl.sum(state * kv[None, :], axis=1)
+        vv *= tl.load(beta + token * num_v_heads + value_head).to(tl.float32)
+        state += vv[:, None] * kv[None, :]
+        out = tl.sum(state * qv[None, :], axis=1)
+        out_ptr = output + (token * num_v_heads + value_head) * head_v_dim
+        tl.store(out_ptr + vo, out, mask=vm)
+        token += 1
+    tl.store(state_ptr, state, mask=sm)
+
+
+def packed_gdn_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    states: torch.Tensor,
+    state_indices: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+) -> torch.Tensor:
+    num_k_heads, head_k_dim = q.shape[-2:]
+    num_v_heads, head_v_dim = v.shape[-2:]
+    output = torch.empty_like(v)
+    block_k = triton.next_power_of_2(head_k_dim)
+    block_v = min(triton.next_power_of_2(head_v_dim), 32)
+    grid = (triton.cdiv(head_v_dim, block_v), state_indices.shape[0] * num_v_heads)
+    _packed_gdn_prefill_kernel[grid](
+        q,
+        k,
+        v,
+        g,
+        beta,
+        output,
+        states,
+        state_indices,
+        cu_seqlens,
+        states.stride(0),
+        head_k_dim**-0.5,
+        num_k_heads=num_k_heads,
+        num_v_heads=num_v_heads,
+        head_k_dim=head_k_dim,
+        head_v_dim=head_v_dim,
+        block_k=block_k,
+        block_v=block_v,
+        num_warps=1,
+        num_stages=3,
+    )
+    return output
+
+
+class GatedDeltaNetBackend:
+    """Fused GDN execution over model-owned recurrent state buffers."""
+
+    def __init__(self, prefill_backend: str, decode_backend: str):
+        supported = {"flashinfer", "triton"}
+        if prefill_backend not in supported or decode_backend not in supported:
+            raise ValueError("GDN backends must be one of: flashinfer, triton")
+        self.prefill_backend = prefill_backend
+        self.decode_backend = decode_backend
+        (
+            self._causal_conv1d_fwd,
+            self._gdn_prefill,
+            self._gdn_decode,
+        ) = _load_gdn_kernels(prefill_backend, decode_backend)
+
+    def prefill(
+        self,
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        conv_weight: torch.Tensor,
+        conv_states: torch.Tensor,
+        ssm_states: torch.Tensor,
+        state_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        query_start_loc_i64: torch.Tensor,
+        a_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        num_k_heads: int,
+        num_v_heads: int,
+        head_k_dim: int,
+        head_v_dim: int,
+    ) -> torch.Tensor:
+        conv_input = mixed_qkv.transpose(0, 1).contiguous()
+        self._causal_conv1d_fwd(
+            conv_input,
+            conv_weight,
+            None,
+            conv_states,
+            query_start_loc,
+            state_indices,
+            None,
+            True,
+            -1,
+        )
+        mixed_qkv = conv_input.transpose(0, 1)
+
+        q, k, v, g, beta = split_l2norm_qkv_gates(
+            mixed_qkv,
+            a,
+            b,
+            a_log,
+            dt_bias,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+        )
+
+        if self.prefill_backend == "triton":
+            return packed_gdn_prefill(
+                q,
+                k,
+                v,
+                g,
+                beta,
+                ssm_states,
+                state_indices,
+                query_start_loc,
+            )
+
+        # SFLLM has no prefix cache or chunked prefill, so EXTEND starts from
+        # zero state.  Only the final state is materialized for later decode.
+        output_state = ssm_states.new_empty(
+            (state_indices.shape[0], *ssm_states.shape[1:]),
+        )
+        output, output_state = self._gdn_prefill(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=None,
+            output_final_state=True,
+            cu_seqlens=query_start_loc_i64,
+            use_qk_l2norm_in_kernel=False,
+            output_state=output_state,
+            use_cp=True,
+        )
+        scatter_recurrent_state(output_state, ssm_states, state_indices)
+        return output
+
+    def decode(
+        self,
+        projected_qkvz: torch.Tensor,
+        projected_ba: torch.Tensor,
+        *,
+        conv_weight: torch.Tensor,
+        conv_states: torch.Tensor,
+        ssm_states: torch.Tensor,
+        state_indices: torch.Tensor,
+        a_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        num_k_heads: int,
+        num_v_heads: int,
+        head_k_dim: int,
+        head_v_dim: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        mixed_qkv, z, b, a = fused_qkvzba_conv_decode(
+            projected_qkvz,
+            projected_ba,
+            conv_states,
+            conv_weight,
+            state_indices,
+            num_v_heads,
+            head_v_dim,
+        )
+        if self.decode_backend == "triton":
+            core = packed_gdn_decode(
+                mixed_qkv=mixed_qkv,
+                a=a,
+                b=b,
+                a_log=a_log,
+                dt_bias=dt_bias,
+                states=ssm_states,
+                state_indices=state_indices,
+                num_k_heads=num_k_heads,
+            )
+        else:
+            key_dim = num_k_heads * head_k_dim
+            value_dim = num_v_heads * head_v_dim
+            q, k, v = mixed_qkv.split((key_dim, key_dim, value_dim), dim=-1)
+            core, _ = self._gdn_decode(
+                q=q.view(-1, 1, num_k_heads, head_k_dim),
+                k=k.view(-1, 1, num_k_heads, head_k_dim),
+                v=v.view(-1, 1, num_v_heads, head_v_dim),
+                output=v.new_empty((v.shape[0], 1, num_v_heads, head_v_dim)),
+                state=None,
+                A_log=a_log,
+                a=a.view(-1, 1, num_v_heads),
+                dt_bias=dt_bias,
+                b=b.view(-1, 1, num_v_heads),
+                use_qk_l2norm=True,
+                initial_state=ssm_states,
+                initial_state_indices=state_indices,
+            )
+            core = core.view(-1, num_v_heads, head_v_dim)
+        return core, z

--- a/python/sfllm/layers/layernorm.py
+++ b/python/sfllm/layers/layernorm.py
@@ -18,6 +18,7 @@ from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
+import sf_kernel
 
 try:
     import flashinfer.norm as _flashinfer_norm
@@ -119,8 +120,6 @@ class RMSNorm(CustomOp):
             )
             return x, residual
 
-        import sf_kernel
-
         out = torch.empty_like(x)
         sf_kernel.rmsnorm(
             out,
@@ -139,7 +138,7 @@ class GemmaRMSNorm(CustomOp):
         eps: float = 1e-6,
     ) -> None:
         super().__init__()
-        self.weight = nn.Parameter(torch.zeros(hidden_size))
+        self.weight = nn.Parameter(torch.zeros(hidden_size), requires_grad=False)
         self.variance_epsilon = eps
 
     def forward_native(
@@ -158,6 +157,29 @@ class GemmaRMSNorm(CustomOp):
         x = x * (1.0 + self.weight.float())
         x = x.to(orig_dtype)
         return x if residual is None else (x, residual)
+
+    def forward_cuda(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        # Both CUDA paths keep normalization and (1 + weight) in FP32.
+        # Residual addition is fused into the same kernel.
+        if _flashinfer_norm is None:
+            out = torch.empty_like(x)
+            sf_kernel.rmsnorm(
+                out, x, self.weight, self.variance_epsilon, residual,
+                gemma_style=True,
+            )
+            return out if residual is None else (out, residual)
+        if residual is None:
+            return _flashinfer_norm.gemma_rmsnorm(
+                x, self.weight, self.variance_epsilon
+            )
+        _flashinfer_norm.gemma_fused_add_rmsnorm(
+            x, residual, self.weight, self.variance_epsilon
+        )
+        return x, residual
 
 class Gemma3RMSNorm(CustomOp):
     def __init__(self, dim: int, eps: float = 1e-6):

--- a/python/sfllm/model_loader/model_config.py
+++ b/python/sfllm/model_loader/model_config.py
@@ -11,6 +11,17 @@ from transformers import PretrainedConfig
 import transformers
 
 
+def get_pool_index_layers(config: PretrainedConfig) -> List[int]:
+    """Return KV-bearing text-model layer IDs in execution order."""
+    layer_types = vars(config).get("layer_types")
+    if layer_types is None:
+        return list(range(config.num_hidden_layers))
+    return [
+        i for i, layer_type in enumerate(layer_types)
+        if layer_type in ("full_attention", "sliding_attention")
+    ]
+
+
 class ModelConfig:
     def __init__(
         self,
@@ -30,11 +41,9 @@ class ModelConfig:
         self.is_draft_model = is_draft_model
         self.hf_config = transformers.AutoConfig.from_pretrained(model_path)
 
-        conf_dtype = getattr(self.hf_config, "dtype", None)
-        if conf_dtype is None:
-            conf_dtype = getattr(self.hf_config, "torch_dtype", None)
-            assert conf_dtype is not None, "config dtype is None"
-        conf_dtype = getattr(torch, conf_dtype) if isinstance(conf_dtype, str) else conf_dtype
-        self.dtype = conf_dtype if dtype == "auto" else getattr(torch, dtype)
+        conf_dtype = self.hf_config.dtype or self.hf_config.get_text_config().dtype
+        assert conf_dtype is not None, "config dtype is None"
+        dtypes = {"half": torch.float16, "float16": torch.float16, "bfloat16": torch.bfloat16, "float32": torch.float32}
+        conf_dtype = dtypes[conf_dtype] if isinstance(conf_dtype, str) else conf_dtype
+        self.dtype = conf_dtype if dtype == "auto" else dtypes[dtype]
         self.hf_config.dtype = self.dtype
-

--- a/python/sfllm/models/interfaces.py
+++ b/python/sfllm/models/interfaces.py
@@ -1,0 +1,5 @@
+class HasBatchState:
+    """Model capability for state that follows requests across batch reordering."""
+
+    def prepare_batch_state(self, scheduled_batch) -> None:
+        raise NotImplementedError

--- a/python/sfllm/models/qwen3_5.py
+++ b/python/sfllm/models/qwen3_5.py
@@ -1,0 +1,598 @@
+"""Inference-only, text-path implementation of dense Qwen3.5.
+
+Qwen3.5 alternates full attention with Gated DeltaNet linear-attention
+blocks.  The public checkpoint is a multimodal wrapper; SFLLM intentionally
+loads only its language model here and skips the vision encoder and MTP head.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Tuple
+
+import torch
+from torch import nn
+import sf_kernel
+
+from sfllm.engine.forward_params import ForwardBatch, ForwardMode
+from sfllm.kernels.gdn import GatedDeltaNetBackend, gated_rmsnorm
+from sfllm.layers.layernorm import GemmaRMSNorm
+from sfllm.layers.linear import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from sfllm.layers.logits_processor import LogitsProcessor
+from sfllm.layers.quantization import QuantizationConfig
+from sfllm.layers.radix_attention import RadixAttention
+from sfllm.layers.rotary_embedding import get_rope
+from sfllm.model_loader.model_config import get_pool_index_layers
+from sfllm.model_loader.weight_utils import default_weight_loader
+from sfllm.models.interfaces import HasBatchState
+from sfllm.models.qwen2 import Qwen2MLP
+from sfllm.server_args import get_global_server_args
+from sfllm.utils import add_prefix, make_layers_non_pp
+
+class Qwen3_5GatedDeltaNet(nn.Module):
+    def __init__(
+        self,
+        config,
+        conv_states: torch.Tensor,
+        ssm_states: torch.Tensor,
+        state_indices: torch.Tensor,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.num_k_heads = config.linear_num_key_heads
+        self.num_v_heads = config.linear_num_value_heads
+        self.head_k_dim = config.linear_key_head_dim
+        self.head_v_dim = config.linear_value_head_dim
+        self.key_dim = self.num_k_heads * self.head_k_dim
+        self.value_dim = self.num_v_heads * self.head_v_dim
+        self.conv_dim = self.key_dim * 2 + self.value_dim
+        self.conv_kernel_size = config.linear_conv_kernel_dim
+        self.rms_norm_eps = config.rms_norm_eps
+        self.conv_states = conv_states
+        self.ssm_states = ssm_states
+        self.state_indices = state_indices
+
+        self.in_proj_qkvzba = MergedColumnParallelLinear(
+            self.hidden_size,
+            [
+                self.key_dim,
+                self.key_dim,
+                self.value_dim,
+                self.value_dim,
+                self.num_v_heads,
+                self.num_v_heads,
+            ],
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("in_proj_qkvzba", prefix),
+        )
+        self.conv_weight = nn.Parameter(
+            torch.empty(self.conv_dim, 1, self.conv_kernel_size), requires_grad=False
+        )
+        self.A_log = nn.Parameter(
+            torch.empty(self.num_v_heads, dtype=torch.float32), requires_grad=False
+        )
+        self.dt_bias = nn.Parameter(
+            torch.empty(self.num_v_heads), requires_grad=False
+        )
+        self.norm = nn.Parameter(
+            torch.ones(self.head_v_dim, dtype=torch.float32), requires_grad=False
+        )
+        self.out_proj = RowParallelLinear(
+            self.value_dim,
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("out_proj", prefix),
+        )
+        server_args = get_global_server_args()
+        self.backend = GatedDeltaNetBackend(
+            prefill_backend=(
+                server_args.linear_attn_prefill_backend
+                or server_args.linear_attn_backend
+            ),
+            decode_backend=(
+                server_args.linear_attn_decode_backend
+                or server_args.linear_attn_backend
+            ),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        query_start_loc: Optional[torch.Tensor],
+        query_start_loc_i64: Optional[torch.Tensor],
+    ):
+        num_sequences = (
+            hidden_states.shape[0]
+            if forward_batch.forward_mode == ForwardMode.DECODE
+            else query_start_loc.shape[0] - 1
+        )
+        state_indices = self.state_indices[:num_sequences]
+
+        projected, _ = self.in_proj_qkvzba(hidden_states)
+        projected_qkvz, projected_ba = projected.split(
+            (self.conv_dim + self.value_dim, self.num_v_heads * 2), dim=-1
+        )
+
+        common = dict(
+            conv_weight=self.conv_weight.view(self.conv_dim, self.conv_kernel_size),
+            conv_states=self.conv_states,
+            ssm_states=self.ssm_states,
+            state_indices=state_indices,
+            a_log=self.A_log,
+            dt_bias=self.dt_bias,
+            num_k_heads=self.num_k_heads,
+            num_v_heads=self.num_v_heads,
+            head_k_dim=self.head_k_dim,
+            head_v_dim=self.head_v_dim,
+        )
+        if forward_batch.forward_mode == ForwardMode.DECODE:
+            core, z = self.backend.decode(projected_qkvz, projected_ba, **common)
+        elif forward_batch.forward_mode == ForwardMode.EXTEND:
+            mixed_qkv = projected_qkvz[:, : self.conv_dim]
+            z = projected_qkvz[:, self.conv_dim :].view(
+                -1, self.num_v_heads, self.head_v_dim
+            )
+            b, a = projected_ba.split(self.num_v_heads, dim=-1)
+            core = self.backend.prefill(
+                mixed_qkv,
+                a,
+                b,
+                query_start_loc=query_start_loc,
+                query_start_loc_i64=query_start_loc_i64,
+                **common,
+            )
+        else:
+            raise NotImplementedError(
+                f"Qwen3.5 GDN does not support {forward_batch.forward_mode.name} yet"
+            )
+
+        core = gated_rmsnorm(core, z, self.norm, self.rms_norm_eps).view(
+            hidden_states.shape[0], self.value_dim
+        )
+        output, _ = self.out_proj(core)
+        return output
+
+
+class Qwen3_5Attention(nn.Module):
+    def __init__(
+        self,
+        config,
+        layer_id: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.attn_output_gate = config.attn_output_gate
+        rope = config.rope_parameters
+
+        q_heads = self.num_heads * (2 if self.attn_output_gate else 1)
+        self.qkv_proj = QKVParallelLinear(
+            config.hidden_size,
+            self.head_dim,
+            q_heads,
+            self.num_kv_heads,
+            bias=config.attention_bias,
+            quant_config=quant_config,
+            prefix=add_prefix("qkv_proj", prefix),
+        )
+        self.o_proj = RowParallelLinear(
+            self.q_size,
+            config.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            reduce_results=False,
+            prefix=add_prefix("o_proj", prefix),
+        )
+        self.q_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=config.max_position_embeddings,
+            base=rope.get("rope_theta", 10000000),
+            is_neox_style=True,
+            rope_scaling=rope,
+            dtype=torch.get_default_dtype(),
+            partial_rotary_factor=rope["partial_rotary_factor"],
+        )
+        self.attn = RadixAttention(
+            self.num_heads,
+            self.head_dim,
+            self.head_dim**-0.5,
+            num_kv_heads=self.num_kv_heads,
+            layer_id=layer_id,
+            prefix=add_prefix("attn", prefix),
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        if self.attn_output_gate:
+            q_gate, k, v = qkv.split(
+                (self.q_size * 2, self.kv_size, self.kv_size), dim=-1
+            )
+        else:
+            q_gate, k, v = qkv.split(
+                (self.q_size, self.kv_size, self.kv_size), dim=-1
+            )
+
+        tokens = q_gate.shape[0]
+        q_gate = q_gate.view(
+            tokens, self.num_heads, self.head_dim * (2 if self.attn_output_gate else 1)
+        )
+        q = q_gate[..., :self.head_dim]
+        gate = q_gate[..., self.head_dim:] if self.attn_output_gate else None
+        k = k.view(tokens, self.num_kv_heads, self.head_dim)
+        q_out = torch.empty(q.shape, dtype=q.dtype, device=q.device)
+        k_out = torch.empty(k.shape, dtype=k.dtype, device=k.device)
+        k_cache = v_cache = None
+        if forward_batch.past_key_values is not None:
+            k_cache, v_cache = forward_batch.past_key_values[self.attn.layer_id]
+
+        sf_kernel.gemma_qk_norm_rope(
+            q,
+            k,
+            v.view(tokens, self.num_kv_heads, self.head_dim),
+            q_out,
+            k_out,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            self.rotary_emb.cos_sin_cache,
+            positions,
+            k_cache,
+            v_cache,
+            forward_batch.out_cache_loc,
+            self.q_norm.variance_epsilon,
+        )
+        output = self.attn(
+            q_out.view(tokens, -1), k_out.view(tokens, -1), v,
+            forward_batch, save_kv_cache=False,
+        )
+        if gate is not None:
+            output = output.view(-1, self.q_size)
+            sf_kernel.fused_sigmoid_mul(output, gate)
+        output, _ = self.o_proj(output)
+        return output
+
+
+class Qwen3_5DecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config,
+        layer_id: int,
+        cache_layer_id: Optional[int],
+        state_layer_id: Optional[int],
+        state_buffers: Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        layer_type = config.layer_types[layer_id]
+        self.layer_type = layer_type
+        if layer_type == "full_attention":
+            self.self_attn = Qwen3_5Attention(
+                config,
+                cache_layer_id,
+                quant_config,
+                add_prefix("self_attn", prefix),
+            )
+        elif layer_type == "linear_attention":
+            self.linear_attn = Qwen3_5GatedDeltaNet(
+                config,
+                state_buffers[0][state_layer_id],
+                state_buffers[1][state_layer_id],
+                state_buffers[2],
+                quant_config,
+                add_prefix("linear_attn", prefix),
+            )
+        else:
+            raise ValueError(f"Unsupported Qwen3.5 layer type: {layer_type}")
+        self.mlp = Qwen2MLP(
+            config.hidden_size,
+            config.intermediate_size,
+            config.hidden_act,
+            quant_config,
+            add_prefix("mlp", prefix),
+        )
+        self.input_layernorm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = GemmaRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+        query_start_loc: Optional[torch.Tensor],
+        query_start_loc_i64: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        if self.layer_type == "full_attention":
+            hidden_states = self.self_attn(positions, hidden_states, forward_batch)
+        else:
+            hidden_states = self.linear_attn(
+                hidden_states,
+                forward_batch,
+                query_start_loc,
+                query_start_loc_i64,
+            )
+        hidden_states, residual = self.post_attention_layernorm(
+            hidden_states, residual
+        )
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class Qwen3_5Model(nn.Module):
+    def __init__(
+        self,
+        config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, _freeze=True)
+        server_args = get_global_server_args()
+        linear_attention_layer_ids = [
+            i for i, layer_type in enumerate(config.layer_types)
+            if layer_type == "linear_attention"
+        ]
+        cache_layer_ids = {
+            layer_id: cache_id
+            for cache_id, layer_id in enumerate(get_pool_index_layers(config))
+        }
+        state_layer_ids = {
+            layer_id: state_id
+            for state_id, layer_id in enumerate(linear_attention_layer_ids)
+        }
+
+        max_state_rows = int(server_args.max_running_requests)
+        conv_dim = (
+            2 * config.linear_num_key_heads * config.linear_key_head_dim
+            + config.linear_num_value_heads * config.linear_value_head_dim
+        )
+        self.register_buffer(
+            "conv_states",
+            torch.zeros(
+                len(linear_attention_layer_ids),
+                max_state_rows + 1,
+                conv_dim,
+                config.linear_conv_kernel_dim - 1,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "ssm_states",
+            torch.zeros(
+                len(linear_attention_layer_ids),
+                max_state_rows + 1,
+                config.linear_num_value_heads,
+                config.linear_value_head_dim,
+                config.linear_key_head_dim,
+                dtype={"float32": torch.float32, "bfloat16": torch.bfloat16}[
+                    vars(config).get("mamba_ssm_dtype", "float32")
+                ],
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "state_indices",
+            torch.arange(1, max_state_rows + 1, dtype=torch.int32),
+            persistent=False,
+        )
+        self.prepared_state_batch = None
+        state_buffers = (
+            self.conv_states,
+            self.ssm_states,
+            self.state_indices,
+        )
+        self.layers, self.start_layer, self.end_layer = make_layers_non_pp(
+            config.num_hidden_layers,
+            lambda idx, prefix: Qwen3_5DecoderLayer(
+                config,
+                idx,
+                cache_layer_ids.get(idx),
+                state_layer_ids.get(idx),
+                state_buffers,
+                quant_config,
+                prefix,
+            ),
+            prefix=add_prefix("layers", prefix),
+        )
+        self.norm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def prepare_batch_state(self, scheduled_batch) -> None:
+        batch_size = len(scheduled_batch)
+        padded_batch_size = batch_size + scheduled_batch.forward_batch.padded_token
+        indices = [sequence.request_index + 1 for sequence in scheduled_batch]
+        batch_key = (padded_batch_size, tuple(indices))
+        if batch_key == self.prepared_state_batch:
+            return
+        indices.extend([-1] * scheduled_batch.forward_batch.padded_token)
+        # The pinned allocator retains storage until the async copy completes.
+        self.state_indices[:padded_batch_size].copy_(
+            torch.tensor(indices, dtype=torch.int32, device="cpu", pin_memory=True),
+            non_blocking=True,
+        )
+        self.prepared_state_batch = batch_key
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        hidden_states = self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+        residual = None
+        query_start_loc = None
+        query_start_loc_i64 = None
+        if forward_batch.forward_mode == ForwardMode.EXTEND:
+            query_start_loc = forward_batch.qo_indptr
+            if query_start_loc.shape[0] == 1:
+                query_start_loc = query_start_loc.new_tensor(
+                    (0, hidden_states.shape[0])
+                )
+            query_start_loc_i64 = query_start_loc.to(torch.int64)
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions,
+                hidden_states,
+                forward_batch,
+                residual,
+                query_start_loc,
+                query_start_loc_i64,
+            )
+        if residual is not None:
+            hidden_states, _ = self.norm(hidden_states, residual)
+        else:
+            hidden_states = self.norm(hidden_states)
+        return hidden_states
+
+
+class Qwen3_5ForConditionalGeneration(nn.Module, HasBatchState):
+    """Text-only serving view of a dense Qwen3.5 multimodal checkpoint."""
+
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvzba": [
+            "in_proj_qkv",
+            "in_proj_z",
+            "in_proj_b",
+            "in_proj_a",
+        ],
+    }
+
+    def __init__(
+        self,
+        config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        if quant_config is not None:
+            raise ValueError("Initial Qwen3.5 support is BF16-only")
+        text_config = config.text_config
+        self.config = text_config
+        self.model = Qwen3_5Model(text_config, quant_config, add_prefix("model", prefix))
+        self.lm_head = self.model.embed_tokens if text_config.tie_word_embeddings else ReplicatedLinear(
+            text_config.hidden_size, text_config.vocab_size, bias=False
+        )
+        self.logits_processor = LogitsProcessor(text_config)
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def prepare_batch_state(self, scheduled_batch) -> None:
+        self.model.prepare_batch_state(scheduled_batch)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        get_embedding: bool = False,
+    ):
+        hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
+        if get_embedding:
+            return hidden_states, forward_batch
+        return self.logits_processor(hidden_states, self.lm_head, None, forward_batch)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        params = dict(self.named_parameters())
+        loaded = set()
+
+        for checkpoint_name, loaded_weight in weights:
+            if checkpoint_name.startswith("model.visual.") or checkpoint_name.startswith("mtp."):
+                continue
+            name = checkpoint_name.replace("model.language_model.", "model.", 1)
+            if self.config.tie_word_embeddings and name == "lm_head.weight":
+                continue
+            if ".linear_attn.norm.weight" in name:
+                name = name.replace(".linear_attn.norm.weight", ".linear_attn.norm")
+            if ".linear_attn.conv1d.weight" in name:
+                name = name.replace(".linear_attn.conv1d.weight", ".linear_attn.conv_weight")
+
+            mappings = []
+            if ".linear_attn.in_proj_qkv.weight" in name:
+                chunks = loaded_weight.split(
+                    [
+                        self.config.linear_num_key_heads * self.config.linear_key_head_dim,
+                        self.config.linear_num_key_heads * self.config.linear_key_head_dim,
+                        self.config.linear_num_value_heads * self.config.linear_value_head_dim,
+                    ],
+                    dim=0,
+                )
+                target = name.replace("in_proj_qkv", "in_proj_qkvzba")
+                mappings = [(target, chunk, idx) for idx, chunk in enumerate(chunks)]
+            elif ".linear_attn.in_proj_z.weight" in name:
+                mappings = [(name.replace("in_proj_z", "in_proj_qkvzba"), loaded_weight, 3)]
+            elif ".linear_attn.in_proj_b.weight" in name:
+                mappings = [(name.replace("in_proj_b", "in_proj_qkvzba"), loaded_weight, 4)]
+            elif ".linear_attn.in_proj_a.weight" in name:
+                mappings = [(name.replace("in_proj_a", "in_proj_qkvzba"), loaded_weight, 5)]
+            else:
+                stacked = [
+                    ("qkv_proj", "q_proj", "q"),
+                    ("qkv_proj", "k_proj", "k"),
+                    ("qkv_proj", "v_proj", "v"),
+                    ("gate_up_proj", "gate_proj", 0),
+                    ("gate_up_proj", "up_proj", 1),
+                ]
+                for packed_name, shard_name, shard_id in stacked:
+                    if shard_name in name:
+                        mappings = [(name.replace(shard_name, packed_name), loaded_weight, shard_id)]
+                        break
+                if not mappings:
+                    mappings = [(name, loaded_weight, None)]
+
+            for target_name, tensor, shard_id in mappings:
+                param = params.get(target_name)
+                if param is None:
+                    raise KeyError(
+                        f"Qwen3.5 language weight has no destination: {checkpoint_name} -> {target_name}"
+                    )
+                loader = vars(param).get("_weight_loader", default_weight_loader)
+                if shard_id is None:
+                    loader(param, tensor)
+                else:
+                    loader(param, tensor, shard_id)
+                loaded.add(target_name)
+
+        missing = set(params) - loaded
+        # Tied embeddings appear only once in named_parameters().
+        if self.config.tie_word_embeddings:
+            missing.discard("lm_head.weight")
+        if missing:
+            raise RuntimeError(f"Missing Qwen3.5 language weights: {sorted(missing)}")
+
+
+EntryClass = Qwen3_5ForConditionalGeneration

--- a/python/sfllm/server_args.py
+++ b/python/sfllm/server_args.py
@@ -17,8 +17,12 @@ class ServerArgs:
     # Resource management
     mem_fraction: float = 0.7
     max_context_length: int = 8192
+    max_running_requests: Optional[int] = None
     disable_overlap: bool = False
     attention_backend: Literal["triton", "fa3"] = "triton"
+    linear_attn_backend: Literal["triton", "flashinfer"] = "flashinfer"
+    linear_attn_prefill_backend: Optional[Literal["triton", "flashinfer"]] = None
+    linear_attn_decode_backend: Optional[Literal["triton", "flashinfer"]] = None
     # speculative decoding
     speculative_algorithm: Optional[str] = None
     speculative_draft_model_path: Optional[str] = None
@@ -100,11 +104,38 @@ class ServerArgs:
             help="Disable overlapping of data transfer and computation.",
         )
         parser.add_argument(
+            "--max-running-requests",
+            type=int,
+            default=ServerArgs.max_running_requests,
+            help="Maximum number of requests admitted to a running batch.",
+        )
+        parser.add_argument(
             "--attention-backend",
             type=str.lower,
             default=ServerArgs.attention_backend,
             choices=["triton", "fa3"],
             help="The attention backend to use.",
+        )
+        parser.add_argument(
+            "--linear-attn-backend",
+            type=str.lower,
+            default=ServerArgs.linear_attn_backend,
+            choices=["triton", "flashinfer"],
+            help="Default GDN linear-attention backend.",
+        )
+        parser.add_argument(
+            "--linear-attn-prefill-backend",
+            type=str.lower,
+            default=ServerArgs.linear_attn_prefill_backend,
+            choices=["triton", "flashinfer"],
+            help="GDN prefill backend; inherits --linear-attn-backend when unset.",
+        )
+        parser.add_argument(
+            "--linear-attn-decode-backend",
+            type=str.lower,
+            default=ServerArgs.linear_attn_decode_backend,
+            choices=["triton", "flashinfer"],
+            help="GDN decode backend; inherits --linear-attn-backend when unset.",
         )
         parser.add_argument(
             "--tokenizer-mode",
@@ -185,6 +216,13 @@ class ServerArgs:
         return cls(**{attr: getattr(args, attr) for attr in attrs})
 
     def __post_init__(self):
+        if self.max_running_requests is None:
+            self.max_running_requests = self.cuda_graph_max_bs
+        if self.max_running_requests <= 0:
+            raise ValueError("max_running_requests must be positive")
+        self.cuda_graph_max_bs = min(
+            self.cuda_graph_max_bs, self.max_running_requests
+        )
         import platform
         if platform.system() == "Windows":
             self.mem_fraction = min(self.mem_fraction, 0.56)

--- a/python/sfllm/serving/engine_server.py
+++ b/python/sfllm/serving/engine_server.py
@@ -27,8 +27,14 @@ class EngineServer:
         """Submit a new inference request and return the request ID."""
         import uuid
         request_id = str(uuid.uuid4().hex) + "_" + str(time.time())
+        params = request.sampling_params or {}
         sampling_params = SamplingParams(
-            top_p=request.sampling_params.get("top_p", 1.0), max_new_tokens=request.sampling_params.get("max_new_tokens", 1024)
+            max_new_tokens=params.get("max_new_tokens", 1024),
+            temperature=params.get("temperature", 0.8),
+            top_p=params.get("top_p", 1.0),
+            top_k=params.get("top_k", 1073741824),
+            stop_token_ids=params.get("stop_token_ids"),
+            stop=params.get("stop"),
         )
         sequence = RequestSequence(
             request.text,

--- a/python/sfllm/serving/tokenizer_manager.py
+++ b/python/sfllm/serving/tokenizer_manager.py
@@ -6,6 +6,7 @@ from sfllm.engine.sequence import AbortSequence, DecodeSequence, RequestSequence
 from sfllm.engine.sampling_params import SamplingParams
 from sfllm.serving.req_protocol import GenerateReqInput
 from sfllm.engine.inference_engine import InferenceEngine
+from sfllm.server_args import set_global_server_args_for_scheduler
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,9 @@ class TokenizerManager:
 
     @staticmethod
     def inferengine_event_run_loop(self):
+        # ``spawn`` starts a fresh interpreter, so module globals set by
+        # ServerArgs.__post_init__ in the HTTP parent are not inherited.
+        set_global_server_args_for_scheduler(self.server_args)
         self.inference_engine = InferenceEngine(self.server_args)
         self.ready_flag.value = True
         import queue

--- a/python/sfllm/serving/tokenizer_manager.py
+++ b/python/sfllm/serving/tokenizer_manager.py
@@ -27,11 +27,20 @@ class TokenizerManager:
         self.tokenizer_output_queue = output_queue
 
     def load_tokenizer(self):
-        from transformers import AutoTokenizer
+        from transformers import AutoConfig, AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(self.server_args.model_path, trust_remote_code=True,)
         if self.tokenizer.pad_token is None:
             self.tokenizer.pad_token = self.tokenizer.eos_token
+        model_config = AutoConfig.from_pretrained(self.server_args.model_path)
+        config_values = vars(model_config)
+        text_config = config_values.get("text_config") or model_config
+        model_eos = vars(text_config).get("eos_token_id")
+        if isinstance(model_eos, int):
+            model_eos = (model_eos,)
+        self.eos_token_ids = frozenset(model_eos or ())
+        if self.tokenizer.eos_token_id is not None:
+            self.eos_token_ids |= {self.tokenizer.eos_token_id}
 
     @staticmethod
     def inferengine_event_run_loop(self):
@@ -89,6 +98,17 @@ class TokenizerManager:
                     self.inferengine_input_queue.put(out_sequence)
                 elif isinstance(out_sequence, RequestSequence):
                     out_sequence.init(self.tokenizer)
+                    out_sequence.sampling_params.stop_token_ids |= self.eos_token_ids
+                    stop_token_sequences = []
+                    for stop in out_sequence.sampling_params.stop:
+                        token_ids = tuple(
+                            self.tokenizer.encode(stop, add_special_tokens=False)
+                        )
+                        if token_ids:
+                            stop_token_sequences.append(token_ids)
+                    out_sequence.sampling_params.stop_token_sequences = tuple(
+                        stop_token_sequences
+                    )
                     self.inferengine_input_queue.put(out_sequence)
                 elif isinstance(out_sequence, list):
                     assert isinstance(out_sequence[0], DecodeSequence)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 fastapi>=0.95.0
 pydantic>=2.0.0,<3.0.0  # Using Pydantic v2 with RootModel
-transformers>=4.39.0
+transformers>=5.12.1
 torch>=2.0.1  # Ensure CUDA graph support is available
 # sentencepiece>=0.1.99
 # python-multipart>=0.0.6
 aiohttp>=3.8.4
 safetensors>=0.4.0
+# Qwen3.5 Gated DeltaNet runtime kernels.
+flashinfer-python>=0.6.14
+sglang-kernel>=0.4.6

--- a/sfkernels/csrc/elementwise/activation.cu
+++ b/sfkernels/csrc/elementwise/activation.cu
@@ -67,29 +67,34 @@ __global__ void silu_and_mul_flat_kernel(
   output.cast_store(out + token * d + column);
 }
 
-template <typename T>
+template <typename T, uint32_t vec_size>
 __global__ void fused_sigmoid_mul_kernel(
     T* __restrict__ output,
     const T* __restrict__ gate,
-    const uint64_t num_rows,
     const uint32_t num_heads,
     const uint32_t head_dim,
     const int64_t gate_token_stride,
     const int64_t gate_head_stride) {
-  const uint64_t row = static_cast<uint64_t>(blockIdx.x) * blockDim.y + threadIdx.y;
-  if (row >= num_rows) {
+  const uint32_t token = blockIdx.x;
+  const uint32_t head = blockIdx.y * blockDim.y + threadIdx.y;
+  if (head >= num_heads) {
     return;
   }
-  const uint64_t token = row / num_heads;
-  const uint32_t head = row % num_heads;
+  const uint64_t row = static_cast<uint64_t>(token) * num_heads + head;
   const int64_t gate_offset = token * gate_token_stride +
       head * gate_head_stride;
-  for (uint32_t column = threadIdx.x; column < head_dim; column += blockDim.x) {
+  for (uint32_t column = threadIdx.x * vec_size; column < head_dim;
+       column += blockDim.x * vec_size) {
     const uint64_t index = row * head_dim + column;
-    const float value = to_float(output[index]);
-    const float gate_value = to_float(gate[gate_offset + column]);
-    output[index] = from_float<T>(
-        value * __fdividef(1.0f, 1.0f + __expf(-gate_value)));
+    flashinfer::vec_t<float, vec_size> values, gates;
+    // vec_t converts FP16/BF16 pairs with __half22float2/__bfloat1622float2.
+    values.cast_load(output + index);
+    gates.cast_load(gate + gate_offset + column);
+#pragma unroll
+    for (uint32_t i = 0; i < vec_size; ++i) {
+      values[i] *= __fdividef(1.0f, 1.0f + __expf(-gates[i]));
+    }
+    values.cast_store(output + index);
   }
 }
 #endif
@@ -207,18 +212,36 @@ void fused_sigmoid_mul(at::Tensor& output, const at::Tensor& gate) {
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(output.scalar_type(), c_type, [&] {
 #ifndef USE_ROCM
-    const uint64_t num_rows = num_elements / head_dim;
-    const dim3 block(32, 4);
-    const dim3 grid((num_rows + block.y - 1) / block.y);
-    fused_sigmoid_mul_kernel<c_type>
-        <<<grid, block, 0, stream>>>(
-            static_cast<c_type*>(output.data_ptr()),
-            static_cast<const c_type*>(gate.data_ptr()),
-            num_rows,
-            num_heads,
-            head_dim,
-            gate_token_stride,
-            gate_head_stride);
+    auto launch = [&](auto vector_size) {
+      constexpr uint32_t vec_size = decltype(vector_size)::value;
+      const uint32_t vectors_per_head = head_dim / vec_size;
+      const uint32_t threads_x = std::min(vectors_per_head, 1024U);
+      const dim3 block(threads_x, std::min(num_heads, 1024U / threads_x));
+      const dim3 grid(output.size(0), (num_heads + block.y - 1) / block.y);
+      fused_sigmoid_mul_kernel<c_type, vec_size>
+          <<<grid, block, 0, stream>>>(
+              static_cast<c_type*>(output.data_ptr()),
+              static_cast<const c_type*>(gate.data_ptr()),
+              num_heads,
+              head_dim,
+              gate_token_stride,
+              gate_head_stride);
+    };
+    // Use the widest safe vector for both pointers and every row/head start.
+    const uintptr_t alignment = reinterpret_cast<uintptr_t>(output.data_ptr()) |
+        reinterpret_cast<uintptr_t>(gate.data_ptr()) |
+        (head_dim * sizeof(c_type)) |
+        (gate_token_stride * sizeof(c_type)) |
+        (gate_head_stride * sizeof(c_type));
+    if (alignment % 16 == 0) {
+      launch(std::integral_constant<uint32_t, 16 / sizeof(c_type)>{});
+    } else if (alignment % 8 == 0) {
+      launch(std::integral_constant<uint32_t, 8 / sizeof(c_type)>{});
+    } else if (alignment % 4 == 0) {
+      launch(std::integral_constant<uint32_t, 4 / sizeof(c_type)>{});
+    } else {
+      launch(std::integral_constant<uint32_t, 1>{});
+    }
     return true;
 #else
     TORCH_CHECK(false, "fused_sigmoid_mul is only available on CUDA");

--- a/sfkernels/tests/test_ops.py
+++ b/sfkernels/tests/test_ops.py
@@ -202,24 +202,15 @@ def test_qk_norm_rope_and_cache(dtype):
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
-@pytest.mark.parametrize("gate_layout", ["unaligned", "projected"])
 @pytest.mark.parametrize("shape", [
     (24, 16, 256), (3, 128, 128), (3, 7, 127), (1, 1, 1),
-    (3, 5, 130), (3, 5, 132),
     (17, 3, 1025), (0, 7, 128), (3, 0, 128),
     (3, 1), (3, 127), (3, 16384),
 ])
-def test_sigmoid_mul_strided_gate(shape, dtype, gate_layout):
+def test_sigmoid_mul_strided_gate(shape, dtype):
     torch.manual_seed(0)
-    if gate_layout == "unaligned":
-        storage = torch.randn(*shape[:-1], 2 * shape[-1] + 1, device="cuda", dtype=dtype)
-        gate = storage[..., 1:shape[-1] + 1]
-    else:
-        heads = shape[1] if len(shape) == 3 else 1
-        dim = shape[-1]
-        storage = torch.randn(shape[0], (2 * heads + 8) * dim, device="cuda", dtype=dtype)
-        strides = (storage.stride(0), 2 * dim, 1) if len(shape) == 3 else (storage.stride(0), 1)
-        gate = storage.as_strided(shape, strides, storage_offset=dim)
+    storage = torch.randn(*shape[:-1], 2 * shape[-1] + 1, device="cuda", dtype=dtype)
+    gate = storage[..., 1:shape[-1] + 1]
     output = torch.randn(shape[0], math.prod(shape[1:]), device="cuda", dtype=dtype)
     expected = (output.float() * gate.float().reshape_as(output).sigmoid()).to(dtype)
 

--- a/sfkernels/tests/test_ops.py
+++ b/sfkernels/tests/test_ops.py
@@ -202,15 +202,24 @@ def test_qk_norm_rope_and_cache(dtype):
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("gate_layout", ["unaligned", "projected"])
 @pytest.mark.parametrize("shape", [
     (24, 16, 256), (3, 128, 128), (3, 7, 127), (1, 1, 1),
+    (3, 5, 130), (3, 5, 132),
     (17, 3, 1025), (0, 7, 128), (3, 0, 128),
     (3, 1), (3, 127), (3, 16384),
 ])
-def test_sigmoid_mul_strided_gate(shape, dtype):
+def test_sigmoid_mul_strided_gate(shape, dtype, gate_layout):
     torch.manual_seed(0)
-    storage = torch.randn(*shape[:-1], 2 * shape[-1] + 1, device="cuda", dtype=dtype)
-    gate = storage[..., 1:shape[-1] + 1]
+    if gate_layout == "unaligned":
+        storage = torch.randn(*shape[:-1], 2 * shape[-1] + 1, device="cuda", dtype=dtype)
+        gate = storage[..., 1:shape[-1] + 1]
+    else:
+        heads = shape[1] if len(shape) == 3 else 1
+        dim = shape[-1]
+        storage = torch.randn(shape[0], (2 * heads + 8) * dim, device="cuda", dtype=dtype)
+        strides = (storage.stride(0), 2 * dim, 1) if len(shape) == 3 else (storage.stride(0), 1)
+        gate = storage.as_strided(shape, strides, storage_offset=dim)
     output = torch.randn(shape[0], math.prod(shape[1:]), device="cuda", dtype=dtype)
     expected = (output.float() * gate.float().reshape_as(output).sigmoid()).to(dtype)
 


### PR DESCRIPTION
Support Qwen3.5-4B text generation with hybrid full-attention/Gated DeltaNet layers, model loading, normalization, and selectable GDN backends.

- Allocate KV storage for full-attention layers and manage recurrent state with stable request slots.
- Initialize serving-worker configuration and honor sampling parameters and model EOS tokens.
- Include the vectorized sigmoid-multiply correction in `sfkernels/csrc/elementwise/activation.cu`.

## Benchmark

Hardware: **NVIDIA H100 NVL, BF16**. ShareGPT, server concurrency 32, client concurrency 24.

| Successful requests | Input tokens | Output tokens | Duration | Output throughput |
| ---: | ---: | ---: | ---: | ---: |
| 1000/1000 | 318819 | 914531 | 218.924 s | **4177.39 tok/s** |

Measured on `54300bc`, 2026-09-07. Mean TTFT: 108.224 ms; mean TPOT: 5.542 ms.

Set the model and dataset paths in both terminals, from the repository root. Use a Python environment with sfllm and its CUDA kernels installed.

```bash
export BENCH_MODEL=/path/to/Qwen3.5-4B
export BENCH_DATASET=/path/to/ShareGPT_V3_unfiltered_cleaned_split.json
export PYTHONPATH="$PWD/python:$PWD/sfkernels/python"
```

Start the server:

```bash
python python/sfllm/serving/app.py \
  --model-path "$BENCH_MODEL" --port 8081 --dtype bfloat16 \
  --max-running-requests 32 --cuda-graph-max-bs 32 \
  --attention-backend fa3 --linear-attn-backend flashinfer --mem-fraction 0.7
```

Wait for `Application startup complete` and a successful health check, then run the client in the second terminal:

```bash
curl --fail http://127.0.0.1:8081/health
python -m sfllm.serving.sgl_bench_seving \
  --backend sglang-native --host 127.0.0.1 --port 8081 \
  --model "$BENCH_MODEL" --tokenizer "$BENCH_MODEL" \
  --dataset-name sharegpt --dataset-path "$BENCH_DATASET" \
  --num-prompts 1000 --max-concurrency 24 \
  --sharegpt-context-len 8192 --sharegpt-output-len 1024 \
  --seed 1 --warmup-requests 1 --disable-ignore-eos \
  --output-details --output-file /tmp/sharegpt-1000.jsonl
```

The client uses streaming and temperature 0, respects EOS, and excludes the warmup request from timing. Wait for the final summary; detailed results are saved in the JSONL file.
