### PR TITLE
perf: improve engine scheduling and serving

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,12 +1,19 @@
 # ShareGPT benchmark
 
-Hardware: **NVIDIA H100 NVL, BF16**. ShareGPT, server concurrency 32, client concurrency 24.
+Hardware: **NVIDIA H100 NVL, BF16**. ShareGPT, 1000/1000 successful requests per run, server concurrency 32, client concurrency 24.
 
-| Successful requests | Input tokens | Output tokens | Duration | Output throughput |
-| ---: | ---: | ---: | ---: | ---: |
-| 1000/1000 | 318819 | 907163 | 208.822 s | **4344.19 tok/s** |
+| Model | Input tokens | Output tokens | Duration | Output tok/s | Acclen |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Qwen3.5-4B | 318819 | 910614 | 209.628 s | 4343.96 | — |
+| Qwen3-4B | 308695 | 1023588 | 225.953 s | 4530.08 | — |
+| Qwen3-4B + EAGLE3 | 308695 | 1024000 | 341.638 s | 2997.32 | 2.93 |
+| Qwen3-4B + DFlash2 | 308695 | 1024000 | 114.030 s | **8980.06** | 4.04 |
 
-Measured 2026-09-07. Mean TTFT: 36.903 ms; mean TPOT: 5.432 ms.
+Measured 2026-09-07. Acclen is the median of logged ShareGPT windows, including the target token. Both speculative runs returned exactly 1024 tokens per request.
+
+GSM8K (1319 questions, 5-shot, greedy, max 512 tokens): Qwen3.5-4B **86.81%**, Qwen3-4B **87.04%**, EAGLE3 **86.88%**, DFlash2 **87.26%**.
+
+Sources: non-speculative `3a1f5d2`; EAGLE3 `3927e5f`; DFlash2 `3927e5f` plus the local checkpoint-config and FA3 context-window compatibility changes.
 
 Set the model and dataset paths in both terminals, from the repository root. Use a Python environment with sfllm and its CUDA kernels installed.
 
@@ -24,6 +31,10 @@ python python/sfllm/serving/app.py \
   --max-running-requests 32 --cuda-graph-max-bs 32 \
   --attention-backend fa3 --linear-attn-backend flashinfer --mem-fraction 0.7
 ```
+
+For DFlash2, set `BENCH_MODEL` to Qwen3-4B and append `--speculative-algorithm dflash2 --speculative-draft-model-path /path/to/Qwen3-4B-speculator.dflash2` (`mgoin/Qwen3-4B-speculator.dflash2`, revision `e3e7a18`). Its config selects block size 8 and a non-causal draft block with 2048 context tokens. Ensure `ninja` is on `PATH`.
+
+For EAGLE3, use Qwen3-4B, replace `--attention-backend fa3` with `--attention-backend triton`, and append `--speculative-algorithm eagle3 --speculative-draft-model-path /path/to/Qwen3-4B_eagle3 --speculative-num-steps 4 --speculative-eagle-topk 4 --speculative-num-draft-tokens 8`.
 
 Wait for `Application startup complete` and a successful health check, then run the client in the second terminal:
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,9 +4,9 @@ Hardware: **NVIDIA H100 NVL, BF16**. ShareGPT, server concurrency 32, client con
 
 | Successful requests | Input tokens | Output tokens | Duration | Output throughput |
 | ---: | ---: | ---: | ---: | ---: |
-| 1000/1000 | 318819 | 914531 | 218.924 s | **4177.39 tok/s** |
+| 1000/1000 | 318819 | 907163 | 208.822 s | **4344.19 tok/s** |
 
-Measured on `54300bc`, 2026-09-07. Mean TTFT: 108.224 ms; mean TPOT: 5.542 ms.
+Measured 2026-09-07. Mean TTFT: 36.903 ms; mean TPOT: 5.432 ms.
 
 Set the model and dataset paths in both terminals, from the repository root. Use a Python environment with sfllm and its CUDA kernels installed.
 

--- a/python/sfllm/engine/inference_engine.py
+++ b/python/sfllm/engine/inference_engine.py
@@ -94,8 +94,18 @@ class InferenceEngine:
                     0,
                 )
                 committed_tokens = committed_tokens[:remaining_tokens]
+                stop_sequences = sequence.sampling_params.stop_token_sequences
+                tail_len = max((len(stop) - 1 for stop in stop_sequences), default=0)
+                recent_tokens = sequence.tokens[
+                    max(sequence.prompt_token_len, sequence.last_generated_token_pos - tail_len)
+                    : sequence.last_generated_token_pos
+                ]
                 for token_idx, token_id in enumerate(committed_tokens):
-                    if token_id in sequence.sampling_params.stop_token_ids:
+                    recent_tokens.append(token_id)
+                    if token_id in sequence.sampling_params.stop_token_ids or any(
+                        tuple(recent_tokens[-len(stop):]) == stop
+                        for stop in stop_sequences
+                    ):
                         committed_tokens = committed_tokens[:token_idx + 1]
                         break
             else:

--- a/python/sfllm/engine/inference_engine.py
+++ b/python/sfllm/engine/inference_engine.py
@@ -9,21 +9,24 @@ import logging
 import torch
 import queue
 from tokenizers.decoders import DecodeStream
-from typing import Dict, Any, List, Tuple, Generator, Union
+from typing import Dict, Any, List, Tuple, Generator
 
 from sfllm.engine.model_worker import ModelWorker
 from sfllm.spec_decoding.dflash2_worker import DFlash2Worker
 from sfllm.spec_decoding.eagle_worker import EagleWorker
 from sfllm.engine.scheduler import Scheduler
 from sfllm.engine.sampling_params import SamplingParams
-from sfllm.engine.sequence import RequestSequence, SequenceStatus, AbortSequence
+from sfllm.engine.sequence import RequestSequence, SequenceStatus, AbortSequence, DecodeSequence
 from sfllm.engine.schedule_batch import ScheduleBatch, BatchResult
 from sfllm.server_args import ServerArgs
-from sfllm.utils.nutils import configure_logger,resolve_future_token_ids
-from sfllm.kernels.triton_utils import split_lastdim_async
-from sfllm.kernels.triton_utils import move_neg1_to_tail, compact_accepted_tokens,prune_kv_indices,split_firstdim_async
+from sfllm.utils.nutils import configure_logger
+from sfllm.kernels.triton_utils import resolve_future_token_ids, split_lastdim_async
+from sfllm.kernels.triton_utils import compact_accepted_tokens, prune_kv_indices
 
 logger = logging.getLogger(__name__)
+OVERLAP_IDLE_WAIT_SECONDS = 0.01
+
+
 class InferenceEngine:
     """Worker that processes inference requests from a queue."""
     
@@ -54,28 +57,35 @@ class InferenceEngine:
         self,
         schedule_batch: ScheduleBatch,
         batch_result: BatchResult,
-        failed_sequences: List[RequestSequence],
-    ) -> List[int]:
-        """Post-process the model outputs and update the sequences."""
+    ) -> List[DecodeSequence]:
+        """Commit tokens and snapshot stream deltas or terminal responses."""
         if not isinstance(batch_result, BatchResult):
             assert False, "Only BatchResult is supported now."
 
         self.scheduler.metrics.update_spec_metrics(batch_result.spec_info)
         self.scheduler.metrics.log_prefill_metrics(schedule_batch)
         self.scheduler.metrics.log_decode_metrics(schedule_batch)
-        token_ids = batch_result.next_token_ids.tolist()
+        token_ids_tensor = batch_result.next_token_ids
+        if self.enable_overlap and token_ids_tensor.device.type != "cpu":
+            raise RuntimeError("overlap output must be staged in host memory")
+        if token_ids_tensor.device.type != "cpu":
+            token_ids_tensor = token_ids_tensor.to("cpu")
+        token_ids = memoryview(token_ids_tensor.numpy())
         if self.is_spec_algo:
             # TODO parallel decoding with speculative decoding, multitoken would be decoded in a single step
             accept_length_cpu = batch_result.spec_info.accept_length_cpu.clamp(min=0)
-            cum_token_cnts = (accept_length_cpu+1).cumsum(dim=0).tolist()
-            cum_token_cnts = [0] + cum_token_cnts
+            cum_token_cnts = memoryview(
+                (accept_length_cpu + 1).cumsum(dim=0).numpy()
+            )
         
-        valid_ids = set(range(len(schedule_batch)))
+        outputs = []
         for idx, sequence in enumerate(schedule_batch):
+            # The extra in-flight step must not commit a retired request again.
+            if not sequence.status.is_active():
+                continue
             if self.is_spec_algo:
-                committed_tokens = token_ids[
-                    cum_token_cnts[idx] : cum_token_cnts[idx + 1]
-                ]
+                start = 0 if idx == 0 else cum_token_cnts[idx - 1]
+                committed_tokens = list(token_ids[start : cum_token_cnts[idx]])
                 generated_count = (
                     sequence.last_generated_token_pos - sequence.prompt_token_len
                 )
@@ -84,58 +94,45 @@ class InferenceEngine:
                     0,
                 )
                 committed_tokens = committed_tokens[:remaining_tokens]
+                for token_idx, token_id in enumerate(committed_tokens):
+                    if token_id in sequence.sampling_params.stop_token_ids:
+                        committed_tokens = committed_tokens[:token_idx + 1]
+                        break
+            else:
+                committed_tokens = [token_ids[idx]]
 
             if self.enable_overlap:
-                if sequence.status.is_active():
-                    assert sequence.tokens[sequence.last_generated_token_pos] < 0, (
-                        "Last token should be placeholder"
-                    )
-                    assert token_ids[idx] >= 0, "Generated token should be valid"
-                    if self.is_spec_algo:
-                        draft_token_steps = self.server_args.speculative_num_steps+1
-                        last_pos = sequence.last_generated_token_pos
-                        sequence.tokens[last_pos:last_pos+len(committed_tokens)
-                        ] = committed_tokens
-                        sequence.tokens[last_pos + len(committed_tokens) : last_pos + draft_token_steps
-                        ] = []
-                        sequence.generated_tokens = committed_tokens
-                        sequence.last_generated_token_pos += len(sequence.generated_tokens)
-                    else:
-                        sequence.tokens[sequence.last_generated_token_pos] = token_ids[idx]
-                        sequence.generated_tokens[0] = token_ids[idx]
-                        sequence.last_generated_token_pos += 1
+                last_pos = sequence.last_generated_token_pos
+                assert sequence.tokens[last_pos] < 0, "Last token should be placeholder"
+                assert token_ids[idx] >= 0, "Generated token should be valid"
+                reserved_tokens = (
+                    self.server_args.speculative_num_steps + 1 if self.is_spec_algo else 1
+                )
+                sequence.tokens[last_pos:last_pos + reserved_tokens] = committed_tokens
             else:
-                if self.is_spec_algo:
-                    sequence.new_tokens = committed_tokens
-                    sequence.generated_tokens = sequence.new_tokens.copy()
-                    sequence.tokens.extend(sequence.new_tokens)
-                    sequence.last_generated_token_pos += len(sequence.generated_tokens)
-                else:
-                    sequence.new_tokens = token_ids[idx: idx + 1]
-                    sequence.generated_tokens[0] = token_ids[idx]
-                    sequence.tokens.extend(sequence.new_tokens)
-                    sequence.last_generated_token_pos += 1
+                sequence.tokens.extend(committed_tokens)
+            sequence.generated_tokens = committed_tokens
+            sequence.last_generated_token_pos += len(committed_tokens)
+            if sequence.last_generated_token_pos == len(sequence.tokens):
+                sequence.new_tokens = committed_tokens
 
-            if not sequence.is_done():
+            cancelled = sequence.sequence_id in self.scheduler.abort_requests
+            if not cancelled and not sequence.is_done():
                 sequence.status = SequenceStatus.RUNNING
                 if not self.enable_overlap:
                     self.scheduler.running_queue.put(sequence)
-            elif not sequence.status.is_active():
-                # a sequence may be calculted one more step after completed
-                valid_ids.remove(idx)
             else:
                 neg_idx = len(sequence.out_cache_loc)
                 while neg_idx > 0 and sequence.out_cache_loc[neg_idx-1] < 0:
                     neg_idx -= 1
                 sequence.out_cache_loc = sequence.out_cache_loc[:neg_idx]
                 self.scheduler.free_sequence_resources(sequence)
-                sequence.status = SequenceStatus.COMPLETED
-                # abort request may have req_id added after completed, so we need to check again
-                sid = next(iter(self.scheduler.abort_requests), None)
-                # 100 should be safe to set as buffer
-                if sid is not None and sid + 100 < sequence.sequence_id:
-                    self.scheduler.abort_requests.remove(sid)
-        return list(valid_ids)
+                sequence.status = (
+                    SequenceStatus.CANCELLED if cancelled else SequenceStatus.COMPLETED
+                )
+            if sequence.stream or not sequence.status.is_active():
+                outputs.append(DecodeSequence(sequence))
+        return outputs
 
     def new_request(self, prompt: str|Tuple[str, List[int]], sampling_params: SamplingParams) -> int:
         if isinstance(prompt, str):
@@ -166,18 +163,18 @@ class InferenceEngine:
     def step(self):
         """Process a single inference request."""
         new_batch, failed_sequences = self.scheduler.get_next_batch()
-        batch_out = []
+        outputs = []
         if not new_batch.empty():
             new_batch.prepare_inputs()
             new_batch.prepare_sample()
             batch_out = self.model_worker.forward(new_batch)
             if self.is_spec_algo:
                 new_batch = self.model_worker.spec_postprocess(new_batch, batch_out)
-        self.post_forward(new_batch, batch_out, failed_sequences)
-        new_batch.extend(failed_sequences)
-        return new_batch
+            outputs = self.post_forward(new_batch, batch_out)
+        outputs.extend(DecodeSequence(seq) for seq in failed_sequences)
+        return outputs
 
-    def step_overlap(self, timeout: float=None) -> Generator[Dict[str, Any], Any, Any]:
+    def step_overlap(self, timeout: float=None) -> List[DecodeSequence]:
         try:
             new_batch = self.output_batch_queue.get(timeout=timeout)
             return new_batch
@@ -185,32 +182,44 @@ class InferenceEngine:
             return []
 
     @torch.inference_mode()
-    def event_loop_overlap(self, event=None):
+    def event_loop_overlap(self, event=None, input_queue=None):
         """Process a single inference request with overlap."""
         logger.info("Inference engine event loop started.============")
         assert self.enable_overlap, "Overlap must be enabled for event loop."
-        failed_sequences = []
         cur_batch = None
         last_batch = ScheduleBatch([], None)
-        future_limit = 1024*10
         future_token_stride = 1
         device_id = torch.device("cuda:0")
         if self.is_spec_algo:
             num_draft_tokens = self.server_args.speculative_num_draft_tokens
             draft_token_steps = self.server_args.speculative_num_steps+1
             future_token_stride = draft_token_steps
-            target_mem_pool = self.scheduler.mem_pool
-            draft_mem_pool = self.scheduler.draft_memory_pool
             hidden_size = (
                 self.model_worker.draft_model_runner.model.speculative_hidden_size
             )
             dtype = self.model_worker.dtype
-            hidden_states_buf = torch.empty((128, draft_token_steps, hidden_size), device=device_id, dtype=dtype)
+            hidden_states_buf = torch.empty(
+                (
+                    self.server_args.max_running_requests,
+                    draft_token_steps,
+                    hidden_size,
+                ),
+                device=device_id,
+                dtype=dtype,
+            )
+            spec_future_tokenid_buf = torch.empty(
+                (self.server_args.max_running_requests, draft_token_steps),
+                device=device_id,
+                dtype=torch.int64,
+            )
 
-            # target_overlap_pool = torch.tensor(target_mem_pool.alloc_block(4000), dtype=torch.int64, device=device_id)
-            # draft_overlap_pool = torch.tensor(draft_mem_pool.alloc_block(4000), dtype=torch.int64, device=device_id)
-        
-        future_tokenid_bufs = torch.empty(future_limit, device=device_id, dtype=torch.int64)
+        future_tokenid_bufs = torch.empty(
+            self.server_args.max_running_requests * future_token_stride + 1,
+            device=device_id,
+            dtype=torch.int64,
+        )
+        fake_tokenid_key = None
+        fake_tokenid_indices = None
         import time
         compute_stream = self.model_worker.compute_stream
         scheduler_stream = torch.cuda.Stream(device=device_id)
@@ -219,12 +228,25 @@ class InferenceEngine:
                 return event.is_set()
             return False
         while not notified():
+            if input_queue is not None:
+                try:
+                    for _ in range(self.server_args.max_running_requests):
+                        self.add_request(input_queue.get_nowait())
+                except queue.Empty:
+                    pass
             new_batch, failed_seq = self.scheduler.get_next_batch_async(last_batch=last_batch)
-            failed_sequences.extend(failed_seq)
+            if failed_seq:
+                self.output_batch_queue.put([DecodeSequence(seq) for seq in failed_seq])
             if new_batch.empty() and last_batch.empty():
                 if event is None:
                     break
-                time.sleep(0.1)
+                if input_queue is None:
+                    time.sleep(OVERLAP_IDLE_WAIT_SECONDS)
+                else:
+                    try:
+                        self.add_request(input_queue.get(timeout=OVERLAP_IDLE_WAIT_SECONDS))
+                    except queue.Empty:
+                        pass
                 continue
             cur_batch = new_batch
 
@@ -244,14 +266,17 @@ class InferenceEngine:
                     # kv_indices_mtd kv_indptr 
                     # may verified_id, out_cache_loc
                 with torch.cuda.stream(compute_stream):
-                    compute_stream.wait_stream(scheduler_stream)
+                    if self.is_spec_algo:
+                        compute_stream.wait_stream(scheduler_stream)
                     if self.is_spec_algo and cur_batch.forward_batch.is_decode():
                         accept_length = cur_batch.spec_info.accept_length.clamp(min=0)+1
                         accept_length_raw = cur_batch.spec_info.accept_length+1
-                        extra_length = draft_token_steps - accept_length
-                        cum_extra_length = extra_length.cumsum(dim=0)
+                        draft_indptr = cur_batch.forward_batch_spec.qo_indptr
+                        extra_length = draft_indptr[1:] - draft_indptr[:-1] - accept_length
                         cur_batch.position_ids -= extra_length
-                        cur_batch.forward_batch.seq_lens -= extra_length
+                        cur_batch.forward_batch.seq_lens -= torch.where(
+                            accept_length_raw == 0, 0, extra_length
+                        )
                         seq_mask_len = num_draft_tokens * (cur_batch.forward_batch.seq_lens + num_draft_tokens)
                         cum_seq_mask_len = torch.cumsum(seq_mask_len, dim=0, dtype=torch.int32)
                         cur_batch.forward_batch.mask_indptr[1:] = cum_seq_mask_len
@@ -261,11 +286,7 @@ class InferenceEngine:
                         # and lose their last reference when replaced below.
                         # Keep their storage alive through compute-side compaction.
                         x.record_stream(compute_stream)
-                        if cur_batch.spec_info.out_cache_loc is not None:
-                            b = cur_batch.forward_batch_spec.kv_indptr
-                        else:
-                            b = cur_batch.forward_batch_spec.kv_indptr[1:]+torch.arange(1,1+len(cur_batch), device=device_id)
-                            b = torch.cat([torch.zeros((1,), dtype=torch.long, device=device_id), b], dim=0)
+                        b = cur_batch.forward_batch_spec.kv_indptr
                         # x1=x.clone()
                         cur_batch.forward_batch_spec.kv_indices_mtd = compact_accepted_tokens(x, b, cur_batch.forward_batch.seq_lens)
                         cur_batch.forward_batch_spec.kv_indices = cur_batch.forward_batch_spec.kv_indices_mtd
@@ -279,7 +300,7 @@ class InferenceEngine:
                         # x[mask] = -1
                         # x[:] = move_neg1_to_tail(x)
                         # cur_batch.forward_batch_spec.kv_indices_mtd -= extra_length # can't handle it here, may generate_kv_indices_kernel
-                        cur_batch.forward_batch_spec.kv_indptr[1:] -= cum_extra_length
+                        cur_batch.forward_batch_spec.kv_indptr[1:] = cur_batch.forward_batch.seq_lens.cumsum(dim=0)
                         if cur_batch.spec_info.out_cache_loc is not None:
                             # even we don't know the accept index yet, we can adjust it in GPU async
                             # would it affect when this is in the scheduler stream?
@@ -291,7 +312,7 @@ class InferenceEngine:
                             # resolve_out_cache_loc = move_neg1_to_tail(resolve_out_cache_loc)[:draft_token_steps-len(cur_batch)]
                             x = cur_batch.forward_batch.kv_indices
                             prune_kv_indices(resolve_out_cache_loc,x,
-                                cur_batch.forward_batch.kv_indptr, accept_length)
+                                cur_batch.forward_batch.kv_indptr, accept_length_raw)
                             # kv_indptr = cur_batch.forward_batch.kv_indptr[1:]
                             # kv_indices = cur_batch.forward_batch.kv_indices
                             # cum_accept_length = torch.cat([torch.tensor([0], device=device_id), accept_length.cumsum(dim=0)], dim=0)
@@ -306,38 +327,48 @@ class InferenceEngine:
                             # cur_batch.forward_batch.kv_indices[:draft_token_steps-len(cur_batch)] = resolve_out_cache_loc
                             # cur_batch.forward_batch.kv_indices[:] = move_neg1_to_tail(cur_batch.forward_batch.kv_indices)
                             # cur_batch.forward_batch.kv_indices = cur_batch.forward_batch.kv_indices[:len(cur_batch)*num_draft_tokens]
-                        cur_batch.forward_batch.kv_indptr[1:] -= cum_extra_length
+                        cur_batch.forward_batch.kv_indptr[1:] = cur_batch.forward_batch_spec.kv_indptr[1:]
 
                         x = cur_batch.forward_batch_spec.position_ids_extend
                         x.record_stream(compute_stream)
-                        b = torch.arange(0, (len(cur_batch)+1)*draft_token_steps, draft_token_steps, device=device_id)
+                        b = draft_indptr
                         cur_batch.forward_batch_spec.position_ids_extend = compact_accepted_tokens(x, b, accept_length, fill_value=0)
                         x = cur_batch.forward_batch_spec.out_cache_loc
                         x.record_stream(compute_stream)
                         cur_batch.forward_batch_spec.out_cache_loc = compact_accepted_tokens(x, b, accept_length, fill_value=0)
+                        draft_indptr[1:] = accept_length.cumsum(dim=0, dtype=torch.int32)
                         if cur_batch.spec_info.verified_id.shape[0] != cur_batch.forward_batch_spec.position_ids_extend.shape[0]:
                             token_len = cur_batch.spec_info.verified_id.shape[0]
                             cur_batch.forward_batch_spec.position_ids_extend = cur_batch.forward_batch_spec.position_ids_extend[:token_len]
                             cur_batch.forward_batch_spec.out_cache_loc = cur_batch.forward_batch_spec.out_cache_loc[:token_len]
 
                 with torch.cuda.stream(compute_stream):
-                    compute_stream.wait_stream(scheduler_stream)
+                    if not self.is_spec_algo:
+                        compute_stream.wait_stream(scheduler_stream)
                     if cur_batch.forward_batch.is_decode():
                         resolve_future_token_ids(cur_batch.input_ids, future_tokenid_bufs)
                     model_output:BatchResult = self.model_worker.forward(cur_batch)
-                    cur_batch.add_placeholder_token(future_limit, future_token_stride)
+                    batch_key = tuple(seq.request_index for seq in cur_batch)
+                    if batch_key != fake_tokenid_key:
+                        fake_tokenid_indices = cur_batch.fake_tokenid_indices(
+                            future_token_stride
+                        )
+                        fake_tokenid_key = batch_key
+                    cur_batch.add_placeholder_token(future_token_stride)
                     if not self.is_spec_algo:
-                        fake_tokenid_indices = cur_batch.fake_tokenid_indices(future_limit, future_token_stride)
                         assert model_output.next_token_ids.shape[-1] == len(cur_batch)
-                        fake_tokenid_indices = fake_tokenid_indices.to(device=device_id, non_blocking=True)
                         future_tokenid_bufs[fake_tokenid_indices] = model_output.next_token_ids
                     else:
                         raw_accept_length = model_output.spec_info.accept_length
                         update_accept_length = raw_accept_length+1
                         # must !!!!!!!!!!
-                        full_token_size = len(cur_batch) * draft_token_steps 
-                        future_token_out_buffer = future_tokenid_bufs[1:full_token_size+1].view(len(cur_batch), -1)
+                        future_token_out_buffer = spec_future_tokenid_buf[
+                            : len(cur_batch)
+                        ]
                         split_lastdim_async(model_output.next_token_ids, update_accept_length, future_token_out_buffer)
+                        future_tokenid_bufs[fake_tokenid_indices] = (
+                            future_token_out_buffer.view(-1)
+                        )
 
                         # if cur_batch.forward_batch.is_decode():
                         #     # cur_batch.forward_batch.out_cache_loc
@@ -351,15 +382,19 @@ class InferenceEngine:
                         for idx, seq in enumerate(cur_batch):
                             seq.accept_length = raw_accept_length[idx:idx+1]
                             if cur_batch.forward_batch.is_decode():
-                                seq.verified_id = future_token_out_buffer[idx]
+                                token_start = seq.request_index * draft_token_steps + 1
+                                seq.verified_id = future_tokenid_bufs[token_start:token_start + draft_token_steps]
                                 # sync the below code
                                 # seq.verified_id = next_token_ids[cum_update_accept_length[idx]: cum_update_accept_length[idx + 1]]
                                 # seq.hidden_states = model_output.spec_info.hidden_states[cum_update_accept_length[idx]: cum_update_accept_length[idx + 1]]
                                 seq.hidden_states = (model_output.spec_info.hidden_states, cum_update_accept_length[idx:idx+2])
-                                seq.out_cache_loc_lazy = cur_batch.forward_batch.out_cache_loc.view(len(cur_batch), num_draft_tokens)[idx]
+                                seq.out_cache_loc_lazy = (
+                                    model_output.spec_info.out_cache_loc.view(-1, 1),
+                                    cum_update_accept_length[idx:idx+2],
+                                )
                             else:
                                 # the first token generated from prefill
-                                seq.verified_id = model_output.spec_info.verified_id[idx]
+                                seq.verified_id = model_output.spec_info.verified_id[idx:idx+1]
                                 seq.hidden_states = (model_output.spec_info.hidden_states[idx:idx+1], torch.arange(0,2, device=device_id))
                         # replace the spec_info with cpu version
                         async_spec_info = model_output.spec_info
@@ -375,43 +410,40 @@ class InferenceEngine:
                     cur_batch.copy_done.record(compute_stream)
 
             if not last_batch.empty():
-                copy_done, model_output = last_batch.copy_done, last_batch.model_output
-                copy_done.synchronize()
+                model_output = last_batch.model_output
+                last_batch.copy_done.synchronize()
                 if self.is_spec_algo:
                     self.model_worker.spec_postprocess(last_batch, model_output, async_overlap=True)
-                valid_ids = self.post_forward(last_batch, model_output, failed_sequences)
-                # Snapshot before the producer advances these live requests.
-                self.output_batch_queue.put(
-                    [last_batch[i].export_raw_sequence() for i in valid_ids]
-                )
+                self.output_batch_queue.put(self.post_forward(last_batch, model_output))
 
             last_batch = cur_batch
 
 
         logger.info("Inference engine event loop exited.")
 
-    def response(self, new_batch: ScheduleBatch, stream: bool) -> Generator[Dict[str, Any], Any, Any]:
+    def response(self, new_batch: List[DecodeSequence], stream: bool) -> Generator[Dict[str, Any], Any, Any]:
         for sequence in new_batch:
             if stream:
                 if sequence.status in (SequenceStatus.RUNNING, SequenceStatus.COMPLETED):
                     if sequence.sequence_id not in self.decode_states:
                         self.decode_states[sequence.sequence_id] = (
-                            DecodeStream(skip_special_tokens=True), 0
+                            DecodeStream(skip_special_tokens=True), [], 0
                         )
-                    decoder, text_offset = self.decode_states[sequence.sequence_id]
+                    decoder, token_ids, text_offset = self.decode_states[sequence.sequence_id]
+                    token_ids.extend(sequence.tokens)
                     finished = not sequence.status.is_active()
                     if finished:
                         generated_text = self.model_worker.detokenize(
-                            sequence.tokens[sequence.prompt_token_len : sequence.last_generated_token_pos]
+                            token_ids
                         )[text_offset :]
                         self.decode_states.pop(sequence.sequence_id)
                     else:
                         generated_text = decoder.step(
                             self.model_worker.tokenizer.backend_tokenizer,
-                            sequence.generated_tokens,
+                            sequence.tokens,
                         ) or ""
                         self.decode_states[sequence.sequence_id] = (
-                            decoder, text_offset + len(generated_text)
+                            decoder, token_ids, text_offset + len(generated_text)
                         )
                     yield {
                         sequence.sequence_id: {
@@ -422,13 +454,11 @@ class InferenceEngine:
                 elif not sequence.status.is_active():
                     self.decode_states.pop(sequence.sequence_id, None)
             elif not sequence.status.is_active():
-                sequence.generated_text = self.model_worker.detokenize(
-                    sequence.tokens[sequence.prompt_token_len : sequence.last_generated_token_pos],
-                )
+                generated_text = self.model_worker.detokenize(sequence.tokens)
                 yield {
                     sequence.sequence_id: {
                         "prompt": sequence.prompt,
-                        "text": sequence.generated_text,
+                        "text": generated_text,
                     }
                 }
 
@@ -442,7 +472,9 @@ class InferenceEngine:
         if isinstance(prompt, str):
             prompt = [prompt]
         for p in prompt:
-            self.add_request(p, sampling_params)
+            sequence = self.new_request(p, sampling_params)
+            sequence.stream = stream
+            self.add_request(sequence)
 
         while not self.scheduler.is_done():
             yield from self.response(self.step(), stream=stream)
@@ -455,7 +487,9 @@ class InferenceEngine:
         if isinstance(prompt, str):
             prompt = [prompt]
         for p in prompt:
-            self.add_request(p, sampling_params)
+            sequence = self.new_request(p, sampling_params)
+            sequence.stream = stream
+            self.add_request(sequence)
         
         if not stream:
             self.event_loop_overlap()

--- a/python/sfllm/engine/memory_pool.py
+++ b/python/sfllm/engine/memory_pool.py
@@ -1,7 +1,6 @@
 
 from collections import deque
 import logging
-import itertools
 import torch
 from typing import List
 from sfllm.model_loader.model_config import get_pool_index_layers
@@ -120,9 +119,14 @@ class BlockMemoryManager:
 
     def alloc_block(self, token_nums: int) -> List[int]:
         """Allocate a block of memory."""
+        if not self.can_alloc(token_nums):
+            raise RuntimeError(
+                f"Cannot allocate {token_nums} blocks; "
+                f"only {self.num_available_blocks()} are available."
+            )
         block_ids = [
             self.free_block_ids.popleft()
-            for _ in range(min(token_nums, len(self.free_block_ids)))
+            for _ in range(token_nums)
         ]
         self.used_block_ids.update(block_ids)
         return block_ids

--- a/python/sfllm/engine/schedule_batch.py
+++ b/python/sfllm/engine/schedule_batch.py
@@ -1,4 +1,5 @@
 import dataclasses
+import numpy as np
 import torch
 import itertools
 import bisect
@@ -12,16 +13,16 @@ from sfllm.layers.sampler import SamplingBatchInfo
 from sfllm.server_args import get_global_server_args
 from sfllm.spec_decoding.spec_common import SpecInput
 
+
 class ScheduleBatch:
     def __init__(self, sequences, mem_pool, draft_mem_pool=None):
         self.sequences:RequestSequence = sequences
         self.device = torch.device("cuda:0")
         self.forward_batch = ForwardBatch(mem_pool)
         self.forward_batch_spec = ForwardBatch(draft_mem_pool) if draft_mem_pool is not None else None
-        self.fake_ids:torch.Tensor = None
         self.input_ids:torch.Tensor = None
         self.position_ids:torch.Tensor = None
-        self.copy_done:torch.Event = None
+        self.copy_done: Optional[torch.cuda.Event] = None
         self.next_token_ids:torch.Tensor = None
         self.spec_info: SpecInput = None
         ###
@@ -60,23 +61,21 @@ class ScheduleBatch:
         # output_ids = self.next_token_ids[indices_]
         # self.input_ids = output_ids
 
-    def add_placeholder_token(self, future_limit: int, future_token_stride: int = 1):
+    def add_placeholder_token(self, future_token_stride: int = 1):
         for seq in self.sequences:
-            place_id = -((seq.sequence_id*future_token_stride) % future_limit)
+            place_id = -((seq.request_index + 1) * future_token_stride)
             seq.new_tokens = list(reversed(range(place_id, place_id+future_token_stride))) # use negative id as placeholder for future token position
             seq.tokens.extend(seq.new_tokens)
 
-    def fake_tokenid_indices(self, future_limit: int, future_token_stride: int = 1):
-        starts = torch.tensor(
-            [(seq.sequence_id * future_token_stride) % future_limit for seq in self.sequences],
-            dtype=torch.int64, pin_memory=True, device="cpu").to("cuda", non_blocking=True)
-        offsets = torch.arange(-(future_token_stride - 1), 1, dtype=torch.int64, device="cuda")
-        result = (starts[:, None] + offsets).view(-1)
-
-        # fake_ids = [range((seq.sequence_id*future_token_stride) % future_limit) for seq in self.sequences]
-        # fake_ids = torch.tensor(fake_ids, dtype=torch.int64, pin_memory=True).to(self.device, non_blocking=True)
-        self.fake_ids = result
-        return self.fake_ids
+    def fake_tokenid_indices(self, future_token_stride: int = 1):
+        return torch.tensor(
+            [
+                seq.request_index * future_token_stride + offset
+                for seq in self.sequences
+                for offset in range(1, future_token_stride + 1)
+            ],
+            dtype=torch.int64, pin_memory=True, device="cpu",
+        ).to(self.device, non_blocking=True)
 
     @contextmanager
     def switch_spec_forward_batch(self):
@@ -126,7 +125,9 @@ class ScheduleBatch:
             from sfllm.kernels.triton_utils import copy_tensors_to_buffer,move_neg1_to_tail
             self.spec_info = self.spec_info.raw_new()
             self.spec_info.hash = g_hash
-            self.spec_info.verified_id = move_neg1_to_tail(torch.cat([seq.verified_id for seq in self.sequences], dim=-1))
+            self.spec_info.verified_id = move_neg1_to_tail(torch.cat([
+                seq.verified_id[:len(seq.new_tokens)] for seq in self.sequences
+            ], dim=-1))
             self.spec_info.verified_id = torch.where(self.spec_info.verified_id < 0,torch.zeros_like(self.spec_info.verified_id),
                                                   self.spec_info.verified_id)
             self.spec_info.accept_length = torch.cat([seq.accept_length for seq in self.sequences], dim=-1)
@@ -141,10 +142,16 @@ class ScheduleBatch:
                 self.spec_info.hidden_states = self.spec_info.hidden_states[:len(src_hd_list)*draft_steps]
             else:
                 self.spec_info.hidden_states = torch.cat([seq.hidden_states for seq in self.sequences], dim=0)
-            if self.sequences[0].out_cache_loc_lazy is not None:
-                self.spec_info.out_cache_loc = torch.cat([seq.out_cache_loc_lazy for seq in self.sequences])
+            cache_sources = [seq.out_cache_loc_lazy for seq in self.sequences
+                             if seq.out_cache_loc_lazy is not None]
+            if cache_sources:
+                self.spec_info.out_cache_loc = copy_tensors_to_buffer(
+                    [source[0] for source in cache_sources],
+                    torch.stack([source[1] for source in cache_sources]),
+                    cache_sources[0][0].new_empty((self.spec_info.verified_id.numel(), 1)),
+                ).view(-1)
             # self.spec_info.logits = torch.cat([seq.logits for seq in self.sequences])
-    def prepare_decode_for_draft(self, position_ids_list: List[int], is_overlap:bool=False, compute_stream:torch.cuda.Stream=None):
+    def prepare_decode_for_draft(self, position_ids_list: List[int], is_overlap:bool=False):
         # prepare position_ids for draft model extend for last verified tokens
         positions_outs = []
         batch_size = len(self.sequences)
@@ -158,18 +165,17 @@ class ScheduleBatch:
 
         spec_out_cache_loc_list = []
         spec_kv_indices_list = []
-        spec_kv_indices_mtd_list = []
+        spec_kv_indptr_list = [0]
         device = self.device
         for sequence in self.sequences:
             total_draft_len = len(sequence.new_tokens)
-            spec_out_cache_loc_list.extend(sequence.out_cache_loc_spec[-total_draft_len:])
-            total_draft_len_past = -len(sequence.out_cache_loc_spec)
-            # the first decode step, accept_length_cpu is -1
-            # spec_kv_indices_list.extend(sequence.out_cache_loc_spec[:-total_draft_len]) # this is correct, right?
-            spec_kv_indices_list.extend(sequence.out_cache_loc_spec[:-total_draft_len_past]) # actually, it's for extend. it's weird here.
-            # extend attention use the current qk and past kv cache, so need to include the last verified token indeed
-            # no!!!, self attention use the current qk and and all kv cache(including current qk)
-            spec_kv_indices_mtd_list.extend(sequence.out_cache_loc_spec)
+            if (len(sequence.tokens) == sequence.last_generated_token_pos
+                    and sequence.accept_length_cpu[0].item() < 0):
+                spec_out_cache_loc_list.append(0)
+            else:
+                spec_out_cache_loc_list.extend(sequence.out_cache_loc_spec[-total_draft_len:])
+            spec_kv_indptr_list.append(spec_kv_indptr_list[-1] + len(sequence.out_cache_loc_spec))
+            spec_kv_indices_list.extend(sequence.out_cache_loc_spec)
 
         padded_token = self.forward_batch.padded_token
         if padded_token > 0:
@@ -177,19 +183,21 @@ class ScheduleBatch:
             spec_kv_indices_list.extend([0] * padded_token)
         out_cache_loc_spec = torch.tensor(spec_out_cache_loc_list, dtype=torch.int64, pin_memory=True).to(device, non_blocking=True)
         kv_indices_spec = torch.tensor(spec_kv_indices_list, dtype=torch.int64, pin_memory=True).to(device, non_blocking=True)
-        kv_indices_mtd_spec = torch.tensor(spec_kv_indices_mtd_list, dtype=torch.int64, pin_memory=True).to(device, non_blocking=True)
 
         #kv_indptr would be used in two place, extend forward for the latest accepted token,, the other is multi-step draft decode path
-        minux_const = torch.arange(1, len(self.sequences)+1, dtype=torch.int32, pin_memory=True)
-        # sglang dropped the first token
-        # leading zero
-        self.forward_batch_spec.kv_indptr = self.forward_batch.kv_indptr.clone()
-        self.forward_batch_spec.kv_indptr[1:].sub_(minux_const.to(self.device, non_blocking=True))
+        self.forward_batch_spec.kv_indptr = torch.tensor(
+            spec_kv_indptr_list, dtype=torch.int32, pin_memory=True,
+        ).to(device, non_blocking=True)
         self.forward_batch_spec.kv_indices = kv_indices_spec
-        self.forward_batch_spec.kv_indices_mtd = kv_indices_mtd_spec
+        self.forward_batch_spec.kv_indices_mtd = kv_indices_spec[:spec_kv_indptr_list[-1]]
         self.forward_batch_spec.padded_token = padded_token
         self.forward_batch_spec.out_cache_loc = out_cache_loc_spec
-        self.forward_batch_spec.max_extend_len = max([len(seq.new_tokens) for seq in self.sequences])
+        extend_lens = [len(seq.new_tokens) for seq in self.sequences]
+        self.forward_batch_spec.max_extend_len = max(extend_lens)
+        # Overlap resolves these reserved rows to accepted rows before forward.
+        self.forward_batch_spec.qo_indptr = torch.tensor(
+            [0, *itertools.accumulate(extend_lens)], dtype=torch.int32, pin_memory=True,
+        ).to(device, non_blocking=True)
         self.forward_batch_spec.position_ids_extend = torch.tensor(
             position_ids_list, dtype=torch.long, pin_memory=True).to(self.device, non_blocking=True)
 
@@ -212,21 +220,15 @@ class ScheduleBatch:
             hidden_states_buffer,compute_stream = self.overlap_affiliated
             with torch.cuda.stream(compute_stream):
                 self.update_spec_info_if_needed(hidden_states_buffer=hidden_states_buffer)
-                self.forward_batch_spec.qo_indptr = torch.zeros_like(self.forward_batch.kv_indptr)
-                accept_length = self.spec_info.accept_length.clamp(min=0) + 1
-                self.forward_batch_spec.qo_indptr[1:batch_size + 1] = (accept_length).cumsum(dim=0, dtype=torch.int32)
         else:
             self.update_spec_info_if_needed(None)
-            self.forward_batch_spec.qo_indptr = self.forward_batch.kv_indptr.clone()
-            accept_length = self.spec_info.accept_length.clamp(min=0) + 1
-            self.forward_batch_spec.qo_indptr[1:batch_size + 1] = (accept_length).cumsum(dim=0, dtype=torch.int32)
 
     def prepare_inputs(self, is_overlap:bool=False):
         cur_seq_lens_list = [0]
         input_ids_list = []
         position_ids_list = []
         out_cache_loc_list = []
-        kv_indices_list = []
+        kv_indices_parts = []
         prefix_lens_list = [0]
         device = self.device
 
@@ -235,14 +237,17 @@ class ScheduleBatch:
             self.forward_batch.forward_mode = ForwardMode.EXTEND
         else:
             self.forward_batch.forward_mode = ForwardMode.DECODE
-
-        padded_batch_size = batch_size
         padded_token = 0
-        if (self.forward_batch.forward_mode == ForwardMode.DECODE and self.forward_batch_spec is None):
-            padded_batch_size = DEFAULT_CUDA_GRAPH_BATCH_SIZES[
+        if (
+            self.forward_batch.is_decode()
+            and self.forward_batch_spec is None
+            and batch_size <= DEFAULT_CUDA_GRAPH_BATCH_SIZES[-1]
+        ):
+            graph_batch_size = DEFAULT_CUDA_GRAPH_BATCH_SIZES[
                 bisect.bisect_left(DEFAULT_CUDA_GRAPH_BATCH_SIZES, batch_size)
             ]
-            padded_token = padded_batch_size - batch_size
+            if graph_batch_size <= get_global_server_args().cuda_graph_max_bs:
+                padded_token = graph_batch_size - batch_size
 
         for sequence in self.sequences:
             if self.forward_batch.forward_mode == ForwardMode.DECODE:
@@ -256,31 +261,40 @@ class ScheduleBatch:
                 start_pos = len(sequence.tokens) - len(sequence.new_tokens)
             position_ids_list.extend(list(range(start_pos, start_pos+cur_seq_lens_list[-1])))
             prefix_lens_list.append(start_pos)
+            # Local views are copied into the batch-owned pinned buffer below.
+            cache_locs = torch.from_numpy(np.frombuffer(sequence.out_cache_loc, dtype=np.int64))
             if self.forward_batch_spec is not None and self.forward_batch.forward_mode == ForwardMode.DECODE:
-                if is_overlap and sequence.marked is False:
-                    true_lens = len(sequence.tokens) - len(sequence.new_tokens)
-                else:
-                    true_lens = len(sequence.tokens) - 1
+                true_lens = len(sequence.out_cache_loc) - get_global_server_args().speculative_num_draft_tokens
+                prefix_lens_list[-1] = true_lens
                 # target model used for verify, speculative_num_draft_tokens cache loc, different from normal decode
                 out_cache_loc_list.extend(sequence.out_cache_loc[true_lens:])
-                kv_indices_list.extend(sequence.out_cache_loc[:true_lens])
+                kv_indices_parts.append(cache_locs[:true_lens])
             else:
                 out_cache_loc_list.extend(sequence.out_cache_loc[-len(sequence.new_tokens):])
-                kv_indices_list.extend(sequence.out_cache_loc)
+                kv_indices_parts.append(cache_locs)
 
         if padded_token > 0:
             input_ids_list.extend([0]*padded_token)
             position_ids_list.extend([0]*padded_token)
             cur_seq_lens_list.extend([1]*padded_token)
             out_cache_loc_list.extend([0]*padded_token)
-            kv_indices_list.extend([0]*padded_token)
             prefix_lens_list.extend([0]*padded_token)
     
         input_ids = torch.tensor(input_ids_list, dtype=torch.long, pin_memory=True).to(device, non_blocking=True)
         position_ids = torch.tensor(position_ids_list, dtype=torch.long, pin_memory=True).to(device, non_blocking=True)
         cur_seq_lens = torch.tensor(cur_seq_lens_list, dtype=torch.int32, pin_memory=True).to(device, non_blocking=True)
         out_cache_loc = torch.tensor(out_cache_loc_list, dtype=torch.int64, pin_memory=True).to(device, non_blocking=True)
-        kv_indices = torch.tensor(kv_indices_list, dtype=torch.int64, pin_memory=True).to(device, non_blocking=True)
+        num_kv_indices = sum(part.shape[0] for part in kv_indices_parts)
+        kv_indices_cpu = torch.empty(
+            num_kv_indices + padded_token,
+            dtype=torch.int64,
+            device="cpu",
+            pin_memory=True,
+        )
+        torch.cat(kv_indices_parts, out=kv_indices_cpu[:num_kv_indices])
+        if padded_token:
+            kv_indices_cpu[num_kv_indices:].zero_()
+        kv_indices = kv_indices_cpu.to(device, non_blocking=True)
 
         prefix_lens = torch.tensor(prefix_lens_list, dtype=torch.int32, pin_memory=True).to(device, non_blocking=True)
 
@@ -309,15 +323,30 @@ class ScheduleBatch:
                 self.prepare_decode_for_draft(position_ids_list, is_overlap=is_overlap)
 
     def prepare_sample(self):
+        is_all_greedy = all(
+            seq.sampling_params.is_greedy for seq in self.sequences
+        )
+        if is_all_greedy:
+            self.forward_batch.sampling_batch_info = SamplingBatchInfo(
+                temperatures=None,
+                top_ps=None,
+                top_ks=None,
+                min_ps=None,
+                is_all_greedy=True,
+            )
+            return
+
         temperatures = []
         top_ps = []
         top_ks = []
         device = self.device
 
         for seq in self.sequences:
-            temperatures.append(seq.sampling_params.temperature)
+            temperatures.append(
+                1.0 if seq.sampling_params.is_greedy else seq.sampling_params.temperature
+            )
             top_ps.append(seq.sampling_params.top_p)
-            top_ks.append(seq.sampling_params.top_k)
+            top_ks.append(1 if seq.sampling_params.is_greedy else seq.sampling_params.top_k)
         temperatures = torch.tensor(temperatures, dtype=torch.float32, pin_memory=True).to(device, non_blocking=True)
         top_ks = torch.tensor(top_ks, dtype=torch.int32, pin_memory=True).to(device, non_blocking=True)
         top_ps = torch.tensor(top_ps, dtype=torch.float32, pin_memory=True).to(device, non_blocking=True)
@@ -326,7 +355,7 @@ class ScheduleBatch:
             top_ps=top_ps,
             top_ks=top_ks,
             min_ps=torch.zeros_like(top_ps),
-            is_all_greedy=all(seq.sampling_params.is_greedy for seq in self.sequences),
+            is_all_greedy=False,
         )
 
 @dataclasses.dataclass

--- a/python/sfllm/engine/scheduler.py
+++ b/python/sfllm/engine/scheduler.py
@@ -1,4 +1,3 @@
-import time
 import queue
 import logging
 from collections import deque
@@ -78,7 +77,7 @@ class Scheduler:
 
     def swap_req_to_waiting(self, sequence: RequestSequence):
         self.free_sequence_resources(sequence)
-        sequence.out_cache_loc = []
+        del sequence.out_cache_loc[:]
         sequence.out_cache_loc_spec = []
         sequence.status = "WAITING"
         sequence.new_tokens = sequence.tokens.copy()
@@ -90,6 +89,9 @@ class Scheduler:
     def get_next_batch(self, last_batch: ScheduleBatch=None) -> Tuple[ScheduleBatch, List[RequestSequence]]:
         running_sequences = []
         failed_sequences = []
+        if self.enable_overlap:
+            self.flying_batch.merge(last_batch)
+            self.flying_batch.filter()
         # schedule prefill first
         prefill_tokens = 0
 
@@ -101,6 +103,16 @@ class Scheduler:
                 self.free_sequence_resources(sequence)
                 continue
             tokens = self.waiting_queue.queue[0].tokens
+            if len(tokens) > self.max_prefill_tokens:
+                sequence = self.waiting_queue.get()
+                logger.warning(
+                    f"Request has {len(tokens)} prompt tokens, exceeding "
+                    f"the {self.max_prefill_tokens} token prefill limit."
+                )
+                sequence.status = SequenceStatus.FAILED
+                sequence.generated_tokens.clear()
+                failed_sequences.append(sequence)
+                continue
             if not self.scheduler_policy.can_add_prefill_req(self.waiting_queue.queue[0]):
                 break
             if prefill_tokens + len(tokens) > self.max_prefill_tokens:
@@ -119,9 +131,6 @@ class Scheduler:
 
         running_batch = ScheduleBatch(running_sequences, self.mem_pool, self.draft_memory_pool)
         if self.enable_overlap:
-            # remove finished sequences from flying batch
-            self.flying_batch.merge(last_batch)
-            self.flying_batch.filter()
             if len(running_sequences) == 0:
                 # if there is no prefill request, schedule decode requests
                 for seq in self.flying_batch.sequences:
@@ -136,7 +145,11 @@ class Scheduler:
                         # we will only reserver a few of them, the rest will be free after verification
                         seq.out_cache_loc.extend(self.mem_pool.alloc_block(target_verify_len))
                         # for draft model
-                        total_draft_len = best_decode_len # we don't know how much token is accepted at this moment
+                        total_draft_len = (
+                            best_decode_len
+                            if len(seq.tokens) > seq.last_generated_token_pos
+                            else int(seq.accept_length_cpu[0]) + 1
+                        )
                         assert self.draft_memory_pool.can_alloc(total_draft_len)
                         seq.out_cache_loc_spec.extend(self.draft_memory_pool.alloc_block(total_draft_len))
                     else:
@@ -182,12 +195,6 @@ class Scheduler:
             if not self.running_queue.empty():
                 logger.warning("swapping one running req to waiting for free memory.")
                 self.swap_req_to_waiting(self.running_queue.get())
-            elif not self.waiting_queue.empty() and not self.enable_overlap:
-                sequence = self.waiting_queue.get()
-                logger.warning(f"the request's token is too long. has tokens: {len(sequence.tokens)}, max context length: {self.max_context_length}. Marking as FAILED.")
-                sequence.status = "FAILED"
-                failed_sequences.append(sequence)
-                self.free_sequence_resources(sequence)
 
         return running_batch, failed_sequences
 

--- a/python/sfllm/engine/scheduler_metrics.py
+++ b/python/sfllm/engine/scheduler_metrics.py
@@ -56,7 +56,7 @@ class RunningMetrics:
             self.prefill_tokens = cur_prefill_tokens
             self.last_prefill_refresh_time = current_time
             return
-        if elapsed > log_interval or cur_prefill_tokens == 0:
+        if elapsed > log_interval:
             msg = f"Prefill batch. #prefill_tokens: {self.prefill_tokens}. "
             msg += (
                 f"Prefill throughput (token/s): {self.prefill_tokens / elapsed:.2f}, "
@@ -85,7 +85,10 @@ class RunningMetrics:
             return
 
         tps = self.num_generated_tokens / elapsed
-        if (tps > 0 and elapsed > refresh_interval) or (tps == 0 and elapsed > refresh_interval * 10) or is_prefill:
+        if not is_prefill and (
+            (tps > 0 and elapsed > refresh_interval)
+            or (tps == 0 and elapsed > refresh_interval * 10)
+        ):
             msg = f"Decode batch. #running-req: {batch_size}. "
             cache_usage = self.mem_pool.get_usage()
             msg += (

--- a/python/sfllm/engine/sequence.py
+++ b/python/sfllm/engine/sequence.py
@@ -4,6 +4,7 @@ from enum import IntEnum, auto
 import threading
 from typing import List, Callable, Optional
 from dataclasses import dataclass, field
+from array import array
 
 
 class SequenceStatus(IntEnum):
@@ -41,7 +42,16 @@ class AbortSequence:
 class DecodeSequence:
     def __init__(self, request_sequence: 'RequestSequence'):
         self.sequence_id = request_sequence.sequence_id
-        self.tokens = request_sequence.generated_tokens.copy()
+        self.prompt = request_sequence.prompt
+        self.stream = request_sequence.stream
+        self.tokens = (
+            request_sequence.generated_tokens.copy()
+            if request_sequence.stream
+            else request_sequence.tokens[
+                request_sequence.prompt_token_len : request_sequence.last_generated_token_pos
+            ]
+        )
+        self.prompt_token_len = request_sequence.prompt_token_len
         self.text = ""
         self.status = request_sequence.status
         self.completion_tokens = (
@@ -71,22 +81,25 @@ class RequestSequence(RawSequence):
         prompt: str,
         sampling_params: Optional[SamplingParams] = None,
         input_ids: List[int] = None,
+        stream: bool = False,
+        messages: Optional[List[dict]] = None,
     ):
         if sampling_params is None:
             sampling_params = SamplingParams()
         super().__init__(prompt=prompt, sampling_params=sampling_params)
-        self.out_cache_loc = []
+        self.out_cache_loc = array("q")
         self.out_cache_loc_spec = []
-        self.out_cache_loc_lazy = None # tensor on cuda
-        self.marked = False # marked for draft token handling, fill with -1 for the future accepted tokens
+        self.out_cache_loc_lazy = None  # (CUDA source tensor, CUDA [start, end) row range)
         self.request_index = -1
+        self.stream = stream
+        self.messages = messages
         if input_ids is not None:
             self.tokens = input_ids
             self.prompt_token_len = len(input_ids)
             self.last_generated_token_pos = self.prompt_token_len
             self.new_tokens = input_ids.copy()
             self.max_possible_length = sampling_params.max_new_tokens + self.prompt_token_len
-    
+
     def init(self, tokenizer_or_ids: Callable | list):
         if isinstance(tokenizer_or_ids, list):
             self.tokens = tokenizer_or_ids

--- a/python/sfllm/kernels/fa3_attention.py
+++ b/python/sfllm/kernels/fa3_attention.py
@@ -15,10 +15,13 @@ def _build_page_table_kernel(
     page_table_stride: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     APPEND_QUERY: tl.constexpr,
+    PREFIX_WINDOW: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
     prefix_start = tl.load(kv_indptr + batch_idx).to(tl.int64)
     prefix_end = tl.load(kv_indptr + batch_idx + 1).to(tl.int64)
+    if PREFIX_WINDOW > 0:
+        prefix_start = tl.maximum(prefix_start, prefix_end - PREFIX_WINDOW)
     prefix_len = prefix_end - prefix_start
     if APPEND_QUERY:
         query_start = tl.load(qo_indptr + batch_idx).to(tl.int64)
@@ -65,6 +68,7 @@ def build_page_table(
     cache_seqlens: torch.Tensor,
     *,
     append_query: bool,
+    prefix_window: int = -1,
 ) -> None:
     _build_page_table_kernel[(page_table.shape[0],)](
         kv_indices,
@@ -76,6 +80,7 @@ def build_page_table(
         page_table.stride(0),
         BLOCK_SIZE=256,
         APPEND_QUERY=append_query,
+        PREFIX_WINDOW=prefix_window,
         num_warps=4,
     )
 

--- a/python/sfllm/kernels/triton_utils.py
+++ b/python/sfllm/kernels/triton_utils.py
@@ -11,6 +11,47 @@ import triton
 import triton.language as tl
 from typing import List, Optional
 
+@triton.jit(
+    do_not_specialize=["num_tokens"],
+    do_not_specialize_on_alignment=["num_tokens"],
+)
+def _resolve_future_token_ids_kernel(
+    input_ids,
+    future_token_ids,
+    num_tokens,
+    block: tl.constexpr,
+):
+    offsets = tl.program_id(0) * block + tl.arange(0, block)
+    mask = offsets < num_tokens
+    token_ids = tl.load(input_ids + offsets, mask=mask, other=0)
+    is_future = mask & (token_ids < 0)
+    resolved = tl.load(
+        future_token_ids - token_ids,
+        mask=is_future,
+        other=0,
+    )
+    tl.store(
+        input_ids + offsets,
+        tl.where(is_future, resolved, token_ids),
+        mask=mask,
+    )
+
+
+def resolve_future_token_ids(
+    input_ids: torch.Tensor,
+    future_token_ids: torch.Tensor,
+) -> None:
+    """Resolve negative overlap placeholders in place with one GPU launch."""
+    block = 256
+    _resolve_future_token_ids_kernel[(triton.cdiv(input_ids.numel(), block),)](
+        input_ids,
+        future_token_ids,
+        input_ids.numel(),
+        block=block,
+        num_warps=4,
+    )
+
+
 @triton.jit  
 def split_lastdim_kernel(
     next_token_ids_ptr,

--- a/python/sfllm/layers/fa3_attention.py
+++ b/python/sfllm/layers/fa3_attention.py
@@ -71,6 +71,10 @@ class FA3AttentionWorkspace:
             page_table,
             cache_seqlens,
             append_query=not is_decode,
+            prefix_window=(
+                layer.sliding_window_size
+                if forward_batch.forward_mode == ForwardMode.DRAFT_EXTEND else -1
+            ),
         )
         scheduler_metadata = get_scheduler_metadata(
             batch_size=batch_size,

--- a/python/sfllm/model_loader/model_config.py
+++ b/python/sfllm/model_loader/model_config.py
@@ -39,7 +39,21 @@ class ModelConfig:
         self.revision = revision
         self.quantization = quantization
         self.is_draft_model = is_draft_model
-        self.hf_config = transformers.AutoConfig.from_pretrained(model_path)
+        raw_config, _ = PretrainedConfig.get_config_dict(model_path)
+        if raw_config.get("speculators_model_type") == "dflash2":
+            # Speculators counts hidden states from the embedding output (0).
+            dflash_config = dict(raw_config)
+            dflash_config["target_layer_ids"] = [
+                layer_id - 1 for layer_id in raw_config["aux_hidden_state_layer_ids"]
+            ]
+            self.hf_config = transformers.AutoConfig.for_model(
+                **raw_config["transformer_layer_config"],
+                architectures=raw_config["architectures"],
+                dtype=raw_config["dtype"],
+                dflash_config=dflash_config,
+            )
+        else:
+            self.hf_config = transformers.AutoConfig.from_pretrained(model_path)
 
         conf_dtype = self.hf_config.dtype or self.hf_config.get_text_config().dtype
         assert conf_dtype is not None, "config dtype is None"

--- a/python/sfllm/model_loader/registry.py
+++ b/python/sfllm/model_loader/registry.py
@@ -121,3 +121,4 @@ def import_model_classes(package_name: str):
 
 ModelRegistry = _ModelRegistry()
 ModelRegistry.register("sfllm.models")
+ModelRegistry.models["Eagle3LlamaForCausalLM"] = ModelRegistry.models["LlamaForCausalLMEagle3"]

--- a/python/sfllm/models/dflash2.py
+++ b/python/sfllm/models/dflash2.py
@@ -96,11 +96,14 @@ class DFlash2Config:
             or len(layer_types) != num_hidden_layers
         ):
             raise ValueError("DFlash2 requires one layer_types entry per draft layer.")
-        if any(layer_type != "full_attention" for layer_type in layer_types):
+        if len(set(layer_types)) != 1 or layer_types[0] not in (
+            "full_attention", "sliding_attention"
+        ):
             raise ValueError(
-                "The Qwen3 DFlash2 backend currently supports "
-                "full-attention drafts only."
+                "DFlash2 requires uniformly full or sliding attention layers."
             )
+        if layer_types[0] == "sliding_attention" and int(raw.get("sliding_window") or 0) <= 0:
+            raise ValueError("DFlash2 sliding attention requires a positive window.")
         return parsed
 
 
@@ -124,6 +127,11 @@ class DFlash2Attention(Qwen3Attention):
             alt_stream=None,
         )
         self.attn.is_causal = False
+        if config.layer_types[layer_id] == "sliding_attention":
+            self.attn.sliding_window_size = int(config.sliding_window)
+            self.attn.is_causal = not config.dflash_config.get(
+                "sliding_window_non_causal", False
+            )
 
     def materialize_kv(
         self,

--- a/python/sfllm/server_args.py
+++ b/python/sfllm/server_args.py
@@ -9,6 +9,7 @@ class ServerArgs:
     tokenizer_path: Optional[str] = None
     tokenizer_mode: str = "auto"
     tokenizer_worker_num: int = 1
+    request_timeout_seconds: float = 3600
 
     #dtype and quantization
     dtype: Literal["float16", "bfloat16", "float32", "auto"] = "auto"
@@ -40,9 +41,6 @@ class ServerArgs:
 
     # Logging
     log_level: str = "info"
-    enable_debug: bool = False
-
-    # debug options
     enable_debug: bool = False
 
     @staticmethod
@@ -80,6 +78,12 @@ class ServerArgs:
             type=int,
             default=ServerArgs.tokenizer_worker_num,
             help="The worker num of the tokenizer manager.",
+        )
+        parser.add_argument(
+            "--request-timeout-seconds",
+            type=float,
+            default=ServerArgs.request_timeout_seconds,
+            help="Abort a request if no generation result arrives within this interval.",
         )
         parser.add_argument(
             "--cuda-graph-max-bs",

--- a/python/sfllm/serving/app.py
+++ b/python/sfllm/serving/app.py
@@ -169,6 +169,21 @@ def create_app(server_args):
         }
         return result
 
+    @app.get("/v1/models")
+    async def list_models():
+        """Minimal OpenAI-compatible model discovery endpoint."""
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": server_args.model_path,
+                    "object": "model",
+                    "owned_by": "sfllm",
+                }
+            ],
+        }
+
+    @app.get("/server_info")
     @app.get("/get_server_info")
     async def get_server_info():
         # Returns interna states per DP.
@@ -176,6 +191,7 @@ def create_app(server_args):
         return {
             "internal_states": internal_states,
             "version": __version__,
+            "max_running_requests": server_args.max_running_requests,
         }
 
     return app

--- a/python/sfllm/serving/engine_server.py
+++ b/python/sfllm/serving/engine_server.py
@@ -2,6 +2,7 @@ import torch.multiprocessing as multiprocessing
 import logging
 import asyncio
 import time
+import queue
 from typing import Dict, Any
 from sfllm.engine.sampling_params import SamplingParams
 from sfllm.engine.sequence import RequestSequence, AbortSequence,SequenceStatus
@@ -23,7 +24,7 @@ class EngineServer:
             self.tokenizer_input_queue, self.tokenizer_output_queue
         )
 
-    async def submit_request(self, request: GenerateReqInput) -> str:
+    async def submit_request(self, request: GenerateReqInput) -> int:
         """Submit a new inference request and return the request ID."""
         import uuid
         request_id = str(uuid.uuid4().hex) + "_" + str(time.time())
@@ -40,6 +41,8 @@ class EngineServer:
             request.text,
             sampling_params,
             input_ids=request.input_ids,
+            stream=request.stream,
+            messages=request.messages,
         )
         self.req_to_state[sequence.sequence_id] = {
             "response": asyncio.Queue(),
@@ -58,9 +61,17 @@ class EngineServer:
         self.tokenizer_input_queue.put(sequence)
         return sequence.sequence_id
 
-    async def get_response(self, sequence_id: int, timeout: int = 40, streaming: bool = False) -> Any:
+    async def get_response(
+        self,
+        sequence_id: int,
+        timeout: float | None = None,
+        streaming: bool = False,
+    ) -> Any:
         """Get the response for a submitted inference request."""
         state = self.req_to_state[sequence_id]
+        if timeout is None:
+            timeout = self.server_args.request_timeout_seconds
+        last_response = None
         while state["status"].is_active():
             try:
                 response = await asyncio.wait_for(state["response"].get(), timeout=timeout)
@@ -71,9 +82,14 @@ class EngineServer:
                 )
             if streaming:
                 yield response
+            else:
+                last_response = response
         while state["response"].empty() is False:
-            response = state["response"].get_nowait()
-            yield response
+            last_response = state["response"].get_nowait()
+            if streaming:
+                yield last_response
+        if not streaming and last_response is not None:
+            yield last_response
         self.req_to_state.pop(sequence_id)
 
     async def auto_clean_resource_loop(self):
@@ -102,9 +118,13 @@ class EngineServer:
                 self.worker_threads[-1].join()
                 break
             try:
-                response = self.tokenizer_output_queue.get(block=False)
-            except:  # noqa: E722
-                await asyncio.sleep(0.1)
+                # A fixed async sleep adds up to 100 ms to every streamed
+                # token.  Wait in a helper thread so the event loop remains
+                # responsive and wake immediately when inference publishes.
+                response = await asyncio.to_thread(
+                    self.tokenizer_output_queue.get, True, 0.1
+                )
+            except queue.Empty:
                 continue
             import copy
             for sequence_id, output in response.items():
@@ -112,6 +132,8 @@ class EngineServer:
                     self.req_to_state[sequence_id]["response_template"]["text"] += output["text"]
                     new_response = copy.deepcopy(self.req_to_state[sequence_id]["response_template"])
                     new_response["output_ids"] = output["output_ids"]
+                    new_response["status"] = output["status"].name
+                    new_response["meta_info"]["prompt_length"] = output["prompt_length"]
                     new_response["meta_info"]["completion_tokens"] = output["completion_tokens"]
 
                     self.req_to_state[sequence_id]["status"] = output["status"]

--- a/python/sfllm/serving/req_protocol.py
+++ b/python/sfllm/serving/req_protocol.py
@@ -1,7 +1,6 @@
-from pydantic import BaseModel, RootModel
+from pydantic import AliasChoices, BaseModel, Field, RootModel
 from typing import List, Optional, Dict, Union, Literal
 from dataclasses import dataclass
-from message_formatter import format_chat_messages
 
 # OpenAI compatible request models
 class ContentItem(BaseModel):
@@ -22,21 +21,28 @@ class ChatRequest(BaseModel):
     messages: List[Message]
     temperature: Optional[float] = 0.7
     top_p: Optional[float] = 1.0
-    max_new_tokens: Optional[int] = 1024
+    max_new_tokens: Optional[int] = Field(
+        1024, validation_alias=AliasChoices("max_tokens", "max_new_tokens")
+    )
     stream: Optional[bool] = False
+    stop: Optional[Union[str, List[str]]] = None
 
 class CompletionRequest(BaseModel):
     model: str
     prompt: str
     temperature: Optional[float] = 0.7
     top_p: Optional[float] = 1.0
-    max_new_tokens: Optional[int] = 1024
+    max_new_tokens: Optional[int] = Field(
+        1024, validation_alias=AliasChoices("max_tokens", "max_new_tokens")
+    )
     stream: Optional[bool] = False
+    stop: Optional[Union[str, List[str]]] = None
 
 @dataclass
 class GenerateReqInput:
     # The input prompt. It can be a single prompt or a batch of prompts.
     text: Optional[Union[List[str], str]] = None
+    messages: Optional[List[Dict]] = None
     # The token ids for text; one can specify either text or input_ids
     input_ids: Optional[Union[List[List[int]], List[int]]] = None
     # The embeddings for input_ids; one can specify either text or input_ids or input_embeds.
@@ -96,10 +102,15 @@ class GenerateReqInput:
             "temperature": base_model.temperature,
             "top_p": base_model.top_p,
             "max_new_tokens": base_model.max_new_tokens,
+            "stop": base_model.stop,
         }
         obj.stream = base_model.stream
         if isinstance(base_model, ChatRequest):
-            obj.text = format_chat_messages(base_model.messages)
+            obj.text = ""
+            obj.messages = [
+                message.model_dump(exclude_none=True)
+                for message in base_model.messages
+            ]
         elif isinstance(base_model, CompletionRequest):
             obj.text = base_model.prompt
         return obj

--- a/python/sfllm/serving/tokenizer_manager.py
+++ b/python/sfllm/serving/tokenizer_manager.py
@@ -1,15 +1,14 @@
-import asyncio
-import time
 import logging
 from tokenizers.decoders import DecodeStream
 import torch.multiprocessing as multiprocessing
 from sfllm.engine.sequence import AbortSequence, DecodeSequence, RequestSequence
 from sfllm.engine.sampling_params import SamplingParams
 from sfllm.serving.req_protocol import GenerateReqInput
-from sfllm.engine.inference_engine import InferenceEngine
+from sfllm.engine.inference_engine import InferenceEngine, OVERLAP_IDLE_WAIT_SECONDS
 from sfllm.server_args import set_global_server_args_for_scheduler
 
 logger = logging.getLogger(__name__)
+
 
 class TokenizerManager:
     def __init__(self, server_args):
@@ -56,32 +55,30 @@ class TokenizerManager:
         thread = None
         if not self.server_args.disable_overlap:
             th_event = threading.Event()
-            thread = threading.Thread(target=self.inference_engine.event_loop_overlap, args=(th_event,))
+            thread = threading.Thread(
+                target=self.inference_engine.event_loop_overlap,
+                args=(th_event, self.inferengine_input_queue),
+            )
             thread.start()
         while True:
             if not self.running or (thread is not None and not thread.is_alive()):
                 logger.error("Inference engine event loop stopped unexpectedly.")
                 break
-            try:
-                for i in range(10):
-                    req_sequence = self.inferengine_input_queue.get_nowait()
-                    self.inference_engine.add_request(req_sequence)
-            except queue.Empty:  # noqa: E722
-                pass
-            
             if not self.server_args.disable_overlap:
-                seq_group = self.inference_engine.step_overlap(timeout=0.1)
+                seq_group = self.inference_engine.step_overlap(
+                    timeout=OVERLAP_IDLE_WAIT_SECONDS
+                )
             else:
+                try:
+                    for _ in range(self.server_args.max_running_requests):
+                        self.inference_engine.add_request(self.inferengine_input_queue.get_nowait())
+                except queue.Empty:
+                    pass
                 seq_group = self.inference_engine.step()
             if len(seq_group) == 0:
-                time.sleep(0.1)
                 continue
 
-            seq_outputs = []
-            for sequence in seq_group:
-                decode_seq = DecodeSequence(sequence)
-                seq_outputs.append(decode_seq)
-            self.tokenizer_input_queue.put(seq_outputs)
+            self.tokenizer_input_queue.put(seq_group)
         if not self.server_args.disable_overlap:
             th_event.set()
             thread.join()
@@ -100,7 +97,16 @@ class TokenizerManager:
                     self.decode_states.pop(out_sequence.sequence_id, None)
                     self.inferengine_input_queue.put(out_sequence)
                 elif isinstance(out_sequence, RequestSequence):
-                    out_sequence.init(self.tokenizer)
+                    if out_sequence.messages is None:
+                        out_sequence.init(self.tokenizer)
+                    else:
+                        input_ids = self.tokenizer.apply_chat_template(
+                            out_sequence.messages,
+                            tokenize=True,
+                            add_generation_prompt=True,
+                            return_dict=False,
+                        )
+                        out_sequence.init(input_ids)
                     out_sequence.sampling_params.stop_token_ids |= self.eos_token_ids
                     stop_token_sequences = []
                     for stop in out_sequence.sampling_params.stop:
@@ -141,6 +147,7 @@ class TokenizerManager:
                         seq_outputs[seq.sequence_id] = {
                             "text": generated_text,
                             "output_ids": seq.tokens,
+                            "prompt_length": seq.prompt_token_len,
                             "completion_tokens": seq.completion_tokens,
                             "status": seq.status,
                         }

--- a/python/sfllm/spec_decoding/dflash2_worker.py
+++ b/python/sfllm/spec_decoding/dflash2_worker.py
@@ -1,7 +1,6 @@
 """DFlash2 proposal logic on SFLLM's shared speculative protocol."""
 
 import torch
-from transformers import PretrainedConfig
 
 from sfllm.engine.forward_params import ForwardBatch, ForwardMode
 from sfllm.engine.schedule_batch import BatchResult, ScheduleBatch
@@ -10,6 +9,7 @@ from sfllm.kernels.dflash2 import (
     prepare_dflash2_block,
 )
 from sfllm.models.dflash2 import DFlash2Config
+from sfllm.model_loader.model_config import ModelConfig
 from sfllm.server_args import ServerArgs
 from sfllm.spec_decoding.spec_utils import EagleSpecInput, EagleVerifyInput
 from sfllm.spec_decoding.spec_worker import SpeculativeWorker
@@ -55,10 +55,15 @@ class DFlash2Worker(SpeculativeWorker):
                 "The initial DFlash2 backend supports dense target/draft weights only."
             )
 
-        draft_config_dict, _ = PretrainedConfig.get_config_dict(
+        draft_config = ModelConfig(
             server_args.speculative_draft_model_path
-        )
-        checkpoint_config = DFlash2Config.from_hf_config(draft_config_dict)
+        ).hf_config
+        checkpoint_config = DFlash2Config.from_hf_config(draft_config)
+        if (
+            "sliding_attention" in draft_config.layer_types
+            and server_args.attention_backend != "fa3"
+        ):
+            raise ValueError("DFlash2 sliding attention requires --attention-backend fa3.")
 
         # A DFlash block maps directly to the shared Eagle protocol width.
         server_args.speculative_eagle_topk = 1

--- a/python/sfllm/spec_decoding/spec_worker.py
+++ b/python/sfllm/spec_decoding/spec_worker.py
@@ -1,4 +1,5 @@
 import logging
+from array import array
 from typing import Callable
 
 import torch
@@ -144,6 +145,14 @@ class SpeculativeWorker:
         spec_info.verified_id = result.verified_id
         spec_info.hidden_states = verify_input.hidden_states[result.accepted_indices]
         spec_info.accept_length = result.accept_length
+        if not self.server_args.disable_overlap:
+            width = self.server_args.speculative_num_draft_tokens
+            for sequence in scheduled_batch:
+                # This result owns the proposals; the request keeps its root.
+                root = len(sequence.out_cache_loc) - width
+                sequence.out_cache_loc[root + 1:] = (
+                    array("q", [-1]) * self.server_args.speculative_num_steps
+                )
         return BatchResult(
             next_token_ids=result.verified_id,
             next_token_logits=next_token_logits,
@@ -177,11 +186,11 @@ class SpeculativeWorker:
 
         if spec_info.out_cache_loc is not None:
             accepted_cache_locs = spec_info.out_cache_loc.cpu()
-            accepted_cache_locs = accepted_cache_locs[
-                accepted_cache_locs != -1
-            ].tolist()
+            accepted_cache_locs = [
+                loc for loc in memoryview(accepted_cache_locs.numpy()) if loc != -1
+            ]
             rejected_cache_locs = list(
-                set(out_cache_loc_cpu.tolist()) - set(accepted_cache_locs)
+                set(memoryview(out_cache_loc_cpu.numpy())) - set(accepted_cache_locs)
             )
             assert len(rejected_cache_locs) + len(accepted_cache_locs) == len(
                 out_cache_loc_cpu
@@ -195,7 +204,7 @@ class SpeculativeWorker:
                     sequence.out_cache_loc.extend(accepted_cache_locs[:accept_len])
                     accepted_cache_locs = accepted_cache_locs[accept_len:]
             else:
-                num_steps = self.server_args.speculative_num_steps
+                width = self.server_args.speculative_num_steps + 1
                 for idx, sequence in enumerate(scheduled_batch):
                     accept_len = accept_length_cpu[idx].item()
                     sequence_cache_locs = accepted_cache_locs[: 1 + accept_len]
@@ -205,13 +214,10 @@ class SpeculativeWorker:
                         # the accepted proposal slots that follow it.
                         self.main_mem_pool.free_block(sequence_cache_locs[1:])
                         continue
-                    start = draft_token_num + num_steps
-                    sequence.out_cache_loc[-start : -start + accept_len] = (
-                        sequence_cache_locs[1:]
-                    )
-                    sequence.out_cache_loc[
-                        -start + accept_len : -start + num_steps
-                    ] = []
+                    has_next = len(sequence.tokens) - sequence.last_generated_token_pos > width
+                    start = sequence.last_generated_token_pos - 1
+                    end = len(sequence.out_cache_loc) - (width if has_next else 0)
+                    sequence.out_cache_loc[start:end] = array("q", sequence_cache_locs)
 
         if async_overlap:
             num_steps = self.server_args.speculative_num_steps
@@ -219,20 +225,15 @@ class SpeculativeWorker:
                 if not sequence.status.is_active():
                     continue
                 accept_len = batch_output.spec_info.accept_length_cpu[idx].item()
+                sequence.accept_length_cpu = accept_length_cpu[idx:idx + 1]
+                if len(sequence.tokens) - sequence.last_generated_token_pos <= num_steps + 1:
+                    continue
                 offset = len(sequence.out_cache_loc_spec) - (num_steps - accept_len)
                 sequence.out_cache_loc_spec, extra_locs = (
                     sequence.out_cache_loc_spec[:offset],
                     sequence.out_cache_loc_spec[offset:],
                 )
                 self.draft_mem_pool.free_block(extra_locs)
-
-                offset = len(sequence.out_cache_loc) - (draft_token_num - 1)
-                sequence.out_cache_loc, sequence.out_cache_loc_lazy_cpu = (
-                    sequence.out_cache_loc[:offset],
-                    sequence.out_cache_loc[offset:],
-                )
-                sequence.out_cache_loc.extend([-1] * num_steps)
-                sequence.marked = True
 
         if not async_overlap:
             for idx, sequence in enumerate(scheduled_batch):

--- a/python/sfllm/utils/nutils.py
+++ b/python/sfllm/utils/nutils.py
@@ -31,11 +31,3 @@ def get_device_core_count(device_id: int = 0) -> int:
         return torch.cuda.get_device_properties(device_id).multi_processor_count
 
     return 0
-
-# @torch.compile(dynamic=True, backend="inductor")
-def resolve_future_token_ids(input_ids, future_token_ids_map):
-    input_ids[:] = torch.where(
-        input_ids < 0,
-        future_token_ids_map[torch.clamp(-input_ids, min=0)],
-        input_ids,
-    )


### PR DESCRIPTION
Reduce repeated batch preparation and CPU scheduling overhead; improve overlap and speculative KV handling.

H100 NVL, BF16. ShareGPT: 1000 requests, server 32 / client 24. GSM8K: 1319 questions, 5-shot, greedy, max 512 output tokens.

| Model | Output tok/s | Acclen | GSM8K |
| --- | ---: | ---: | ---: |
| Qwen3.5-4B | 4343.96 | — | 1145/1319 (86.81%) |
| Qwen3-4B | 4530.08 | — | 1148/1319 (87.04%) |
| sfllm: Qwen3-4B + EAGLE3 | 2997.32 | 2.93 median | 1146/1319 (86.88%) |
| sfllm: Qwen3-4B + DFlash2 | 8980.06 | 4.04 median | 1151/1319 (87.26%) |
| SGLang: Qwen3-4B + EAGLE3 | 2661.72 | 2.82 mean | — |

Qwen3-4B + EAGLE3 details (1000 successful requests each):

| Metric | sfllm | SGLang |
| --- | ---: | ---: |
| Input tokens | 308695 | 308695 |
| Output tokens | 1024000 | 1022155 |
| Duration | 341.638 s | 384.021 s |
| Requests/s | 2.927 | 2.604 |
| Output length: mean / min / max | 1024 / 1024 / 1024 | 1022.155 / 11 / 1024 |
| Outputs at the 1024-token cap | 1000/1000 | 996/1000 |
| TTFT: mean / P99 | 53.90 / 192.40 ms | 64.61 / 827.89 ms |
| TPOT: mean / P99 | 7.854 / 12.502 ms | 8.827 / 13.943 ms |
| End-to-end latency: mean / P99 | 8.088 / 12.860 s | 9.069 / 14.334 s |

Lengths use server-reported completion tokens. Both have output-length P50/P95/P99 = 1024 and zero outputs above 1024. SGLang has four shorter outputs: 11, 614, 778, and 848 tokens; total output is 1845 tokens (0.18%) lower.

sfllm acclen is the median of ShareGPT log windows; SGLang acclen is the server-reported cumulative mean. Both include the target token. Non-speculative runs use FA3; EAGLE3 uses Triton, 4 steps, top-k 4, 8 draft tokens, and `Qwen3-4B_eagle3`.

SGLang `02d9b30`: same client and checkpoints, prefix caching disabled. Its `--decrypted-draft-config-file` option maps the draft architecture name to the built-in `LlamaForCausalLMEagle3`; weights and the original checkpoint config are unchanged. GSM8K was not run for this SGLang EAGLE3 comparison.

Benchmark sources: non-speculative `3a1f5d2`, sfllm EAGLE3 `3927e5f`, sfllm DFlash2 `eba03f0`. The stop-sequence and DFlash2 compatibility fixes are included in this PR.

Server/client commands and warmup settings: [benchmark/README.md](https://github.com/wejoncy/sfllm/blob/eba03f0d4dd26bf2555d2df00690c5741e9144ef/benchmark/README.md#sharegpt-benchmark).

DFlash2: `mgoin/Qwen3-4B-speculator.dflash2` revision `e3e7a18`, FA3, block size 8 (7 draft tokens). The checkpoint's 2048-token context window and non-causal draft block are preserved. No attention algorithm or checkpoint weights were replaced.

1000/1000 successful requests: 308695 input tokens, 1024000 output tokens, 114.030 s, 8.770 requests/s. Every output is exactly 1024 tokens; no over-limit outputs. TTFT mean/P99: 36.11/433.45 ms; TPOT mean/P99: 2.570/4.394 ms; end-to-end mean/P99: 2.665/4.556 s. Acclen 4.04 is the median of 58 logged ShareGPT windows, including the target token, not a cumulative weighted mean. GSM8K: zero stop overruns and zero text/token mismatches across all 1319 responses.

DFlash2 commands (current checkout; Python environment includes sfllm, sfkernels, FA3, and `ninja`):

```bash
export PATH="/workspace/sglang/.venv/bin:$PATH"
export PYTHONPATH="$PWD/python:$PWD/sfkernels/python"
export BENCH_MODEL=/mnt/data/jicwen/work/Qwen3-4B
export BENCH_DRAFT=/mnt/data/jicwen/work/Qwen3-4B-speculator.dflash2
export BENCH_DATASET=/mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json
python python/sfllm/serving/app.py \
  --model-path "$BENCH_MODEL" --port 8081 --dtype bfloat16 \
  --max-running-requests 32 --cuda-graph-max-bs 32 \
  --attention-backend fa3 --linear-attn-backend flashinfer --mem-fraction 0.7 \
  --speculative-algorithm dflash2 --speculative-draft-model-path "$BENCH_DRAFT"
```

After `Application startup complete`, in a second terminal with the same environment:

```bash
curl --fail http://127.0.0.1:8081/health
python -m sfllm.serving.sgl_bench_seving \
  --backend sglang-native --host 127.0.0.1 --port 8081 \
  --model "$BENCH_MODEL" --tokenizer "$BENCH_MODEL" \
  --dataset-name sharegpt --dataset-path "$BENCH_DATASET" \
  --num-prompts 1000 --max-concurrency 24 \
  --sharegpt-context-len 8192 --sharegpt-output-len 1024 \
  --seed 1 --warmup-requests 1 --disable-ignore-eos \
  --output-details --output-file /tmp/qwen3-dflash2-sharegpt-1000.jsonl
```

Exact run commands and raw results: `/tmp/sfllm-dflash2-compat.qn4q1eph/eval/` (`run-config.json`, `results.jsonl`, `validated-summary.json`, `gsm8k/results.jsonl`, `gsm8k/responses.jsonl`). The 1000 requests exclude warmup and match the previous Qwen3-4B input lengths.
