### PR TITLE
fix: preserve output correctness and use FA3 automatic splitting

### DIFF
--- a/python/sfllm/engine/inference_engine.py
+++ b/python/sfllm/engine/inference_engine.py
@@ -378,7 +378,10 @@ class InferenceEngine:
                 if self.is_spec_algo:
                     self.model_worker.spec_postprocess(last_batch, model_output, async_overlap=True)
                 valid_ids = self.post_forward(last_batch, model_output, failed_sequences)
-                self.output_batch_queue.put([last_batch[i] for i in valid_ids])
+                # Snapshot before the producer advances these live requests.
+                self.output_batch_queue.put(
+                    [last_batch[i].export_raw_sequence() for i in valid_ids]
+                )
 
             last_batch = cur_batch
 
@@ -389,7 +392,7 @@ class InferenceEngine:
         seq_outputs = {}
         for sequence in new_batch:
             if stream:
-                if sequence.status == SequenceStatus.RUNNING:
+                if sequence.status in (SequenceStatus.RUNNING, SequenceStatus.COMPLETED):
                     new_token = sequence.generated_tokens
                     generated_text = self.model_worker.detokenize(
                         new_token,
@@ -437,8 +440,6 @@ class InferenceEngine:
             while not self.output_batch_queue.empty():
                 new_batch = self.output_batch_queue.get()
                 yield from self.response(new_batch, stream=stream)
-                # all state for a same sequence will share the same sequence object
-                self.output_batch_queue.queue.clear()
             return
 
         import threading

--- a/python/sfllm/engine/inference_engine.py
+++ b/python/sfllm/engine/inference_engine.py
@@ -16,6 +16,7 @@ from sfllm.spec_decoding.eagle_worker import EagleWorker
 from sfllm.engine.scheduler import Scheduler
 from sfllm.engine.sampling_params import SamplingParams
 from sfllm.engine.sequence import RequestSequence, SequenceStatus, AbortSequence
+from sfllm.engine.tokenizer import IncrementalDetokenizer
 from sfllm.engine.schedule_batch import ScheduleBatch, BatchResult
 from sfllm.server_args import ServerArgs
 from sfllm.utils.nutils import configure_logger,resolve_future_token_ids
@@ -41,6 +42,7 @@ class InferenceEngine:
         self.running = False
         self.scheduler = Scheduler(server_args, self.model_worker)
         self.output_batch_queue = queue.Queue()
+        self.decode_states = {}
         self.model_worker.init_capture_cudagraph()
         self.enable_overlap = not server_args.disable_overlap
 
@@ -389,16 +391,27 @@ class InferenceEngine:
         logger.info("Inference engine event loop exited.")
 
     def response(self, new_batch: ScheduleBatch, stream: bool) -> Generator[Dict[str, Any], Any, Any]:
-        seq_outputs = {}
         for sequence in new_batch:
             if stream:
                 if sequence.status in (SequenceStatus.RUNNING, SequenceStatus.COMPLETED):
-                    new_token = sequence.generated_tokens
-                    generated_text = self.model_worker.detokenize(
-                        new_token,
+                    state = self.decode_states.get(sequence.sequence_id)
+                    if state is None:
+                        state = IncrementalDetokenizer(self.model_worker.tokenizer)
+                        self.decode_states[sequence.sequence_id] = state
+                    finished = not sequence.status.is_active()
+                    generated_text = state.append(
+                        sequence.generated_tokens, finished
                     )
-                    seq_outputs[sequence.sequence_id] = {"prompt": sequence.prompt, "text": generated_text}
-                    yield seq_outputs
+                    if finished:
+                        self.decode_states.pop(sequence.sequence_id)
+                    yield {
+                        sequence.sequence_id: {
+                            "prompt": sequence.prompt,
+                            "text": generated_text,
+                        }
+                    }
+                elif not sequence.status.is_active():
+                    self.decode_states.pop(sequence.sequence_id, None)
             elif not sequence.status.is_active():
                 sequence.generated_text = self.model_worker.detokenize(
                     sequence.tokens[sequence.prompt_token_len : sequence.last_generated_token_pos],

--- a/python/sfllm/engine/inference_engine.py
+++ b/python/sfllm/engine/inference_engine.py
@@ -8,6 +8,7 @@ export HSA_ENABLE_DEBUG=1 is useful for ROCm error tracing
 import logging
 import torch
 import queue
+from tokenizers.decoders import DecodeStream
 from typing import Dict, Any, List, Tuple, Generator, Union
 
 from sfllm.engine.model_worker import ModelWorker
@@ -16,7 +17,6 @@ from sfllm.spec_decoding.eagle_worker import EagleWorker
 from sfllm.engine.scheduler import Scheduler
 from sfllm.engine.sampling_params import SamplingParams
 from sfllm.engine.sequence import RequestSequence, SequenceStatus, AbortSequence
-from sfllm.engine.tokenizer import IncrementalDetokenizer
 from sfllm.engine.schedule_batch import ScheduleBatch, BatchResult
 from sfllm.server_args import ServerArgs
 from sfllm.utils.nutils import configure_logger,resolve_future_token_ids
@@ -394,16 +394,25 @@ class InferenceEngine:
         for sequence in new_batch:
             if stream:
                 if sequence.status in (SequenceStatus.RUNNING, SequenceStatus.COMPLETED):
-                    state = self.decode_states.get(sequence.sequence_id)
-                    if state is None:
-                        state = IncrementalDetokenizer(self.model_worker.tokenizer)
-                        self.decode_states[sequence.sequence_id] = state
+                    if sequence.sequence_id not in self.decode_states:
+                        self.decode_states[sequence.sequence_id] = (
+                            DecodeStream(skip_special_tokens=True), 0
+                        )
+                    decoder, text_offset = self.decode_states[sequence.sequence_id]
                     finished = not sequence.status.is_active()
-                    generated_text = state.append(
-                        sequence.generated_tokens, finished
-                    )
                     if finished:
+                        generated_text = self.model_worker.detokenize(
+                            sequence.tokens[sequence.prompt_token_len : sequence.last_generated_token_pos]
+                        )[text_offset :]
                         self.decode_states.pop(sequence.sequence_id)
+                    else:
+                        generated_text = decoder.step(
+                            self.model_worker.tokenizer.backend_tokenizer,
+                            sequence.generated_tokens,
+                        ) or ""
+                        self.decode_states[sequence.sequence_id] = (
+                            decoder, text_offset + len(generated_text)
+                        )
                     yield {
                         sequence.sequence_id: {
                             "prompt": sequence.prompt,

--- a/python/sfllm/engine/sequence.py
+++ b/python/sfllm/engine/sequence.py
@@ -41,11 +41,12 @@ class AbortSequence:
 class DecodeSequence:
     def __init__(self, request_sequence: 'RequestSequence'):
         self.sequence_id = request_sequence.sequence_id
-        self.tokens = request_sequence.generated_tokens
+        self.tokens = request_sequence.generated_tokens.copy()
         self.text = ""
         self.status = request_sequence.status
         self.completion_tokens = (
-            len(request_sequence.tokens) - request_sequence.prompt_token_len
+            request_sequence.last_generated_token_pos
+            - request_sequence.prompt_token_len
         )
 
 

--- a/python/sfllm/engine/tokenizer.py
+++ b/python/sfllm/engine/tokenizer.py
@@ -4,29 +4,6 @@ It handles the tokenization of prompts and messages for the model.
 """
 import torch
 from transformers import AutoTokenizer
-from tokenizers.decoders import DecodeStream
-
-
-class IncrementalDetokenizer:
-    """Decode generated token deltas without splitting UTF-8 characters."""
-
-    def __init__(self, tokenizer):
-        self.tokenizer = tokenizer
-        self.stream = DecodeStream(skip_special_tokens=True)
-        self.token_ids = []
-        self.text_offset = 0
-
-    def append(self, token_ids, finished=False):
-        self.token_ids.extend(token_ids)
-        if finished:
-            # Decode once in full to flush any bytes left at the token limit.
-            return self.tokenizer.decode(
-                self.token_ids, skip_special_tokens=True
-            )[self.text_offset :]
-        delta = self.stream.step(self.tokenizer.backend_tokenizer, token_ids) or ""
-        self.text_offset += len(delta)
-        return delta
-
 
 class Tokenizer:
     def __init__(self, model_name: str):

--- a/python/sfllm/engine/tokenizer.py
+++ b/python/sfllm/engine/tokenizer.py
@@ -4,6 +4,29 @@ It handles the tokenization of prompts and messages for the model.
 """
 import torch
 from transformers import AutoTokenizer
+from tokenizers.decoders import DecodeStream
+
+
+class IncrementalDetokenizer:
+    """Decode generated token deltas without splitting UTF-8 characters."""
+
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+        self.stream = DecodeStream(skip_special_tokens=True)
+        self.token_ids = []
+        self.text_offset = 0
+
+    def append(self, token_ids, finished=False):
+        self.token_ids.extend(token_ids)
+        if finished:
+            # Decode once in full to flush any bytes left at the token limit.
+            return self.tokenizer.decode(
+                self.token_ids, skip_special_tokens=True
+            )[self.text_offset :]
+        delta = self.stream.step(self.tokenizer.backend_tokenizer, token_ids) or ""
+        self.text_offset += len(delta)
+        return delta
+
 
 class Tokenizer:
     def __init__(self, model_name: str):

--- a/python/sfllm/kernels/fa3_attention.py
+++ b/python/sfllm/kernels/fa3_attention.py
@@ -99,7 +99,7 @@ def fa3_attention_fwd(
         max_seqlen_q=metadata.max_query_len,
         softmax_scale=softmax_scale,
         causal=causal,
-        num_splits=1,
+        num_splits=0,
         scheduler_metadata=metadata.scheduler_metadata,
         out=out,
     )

--- a/python/sfllm/layers/fa3_attention.py
+++ b/python/sfllm/layers/fa3_attention.py
@@ -84,7 +84,7 @@ class FA3AttentionWorkspace:
             cu_seqlens_q=qo_indptr,
             page_size=1,
             causal=layer.is_causal,
-            num_splits=1,
+            num_splits=0,
         )
         return FA3AttentionMetadata(
             page_table,

--- a/python/sfllm/serving/tokenizer_manager.py
+++ b/python/sfllm/serving/tokenizer_manager.py
@@ -1,12 +1,12 @@
 import asyncio
 import time
 import logging
+from tokenizers.decoders import DecodeStream
 import torch.multiprocessing as multiprocessing
 from sfllm.engine.sequence import AbortSequence, DecodeSequence, RequestSequence
 from sfllm.engine.sampling_params import SamplingParams
 from sfllm.serving.req_protocol import GenerateReqInput
 from sfllm.engine.inference_engine import InferenceEngine
-from sfllm.engine.tokenizer import IncrementalDetokenizer
 from sfllm.server_args import set_global_server_args_for_scheduler
 
 logger = logging.getLogger(__name__)
@@ -113,7 +113,7 @@ class TokenizerManager:
                         stop_token_sequences
                     )
                     self.decode_states[out_sequence.sequence_id] = (
-                        IncrementalDetokenizer(self.tokenizer)
+                        DecodeStream(skip_special_tokens=True), [], 0
                     )
                     self.inferengine_input_queue.put(out_sequence)
                 elif isinstance(out_sequence, list):
@@ -123,10 +123,21 @@ class TokenizerManager:
                         state = self.decode_states.get(seq.sequence_id)
                         if state is None:
                             continue  # Output already in flight when aborted.
+                        decoder, token_ids, text_offset = state
+                        token_ids.extend(seq.tokens)
                         finished = not seq.status.is_active()
-                        generated_text = state.append(seq.tokens, finished)
                         if finished:
+                            generated_text = self.tokenizer.decode(
+                                token_ids, skip_special_tokens=True
+                            )[text_offset :]
                             self.decode_states.pop(seq.sequence_id)
+                        else:
+                            generated_text = decoder.step(
+                                self.tokenizer.backend_tokenizer, seq.tokens
+                            ) or ""
+                            self.decode_states[seq.sequence_id] = (
+                                decoder, token_ids, text_offset + len(generated_text)
+                            )
                         seq_outputs[seq.sequence_id] = {
                             "text": generated_text,
                             "output_ids": seq.tokens,

--- a/python/sfllm/serving/tokenizer_manager.py
+++ b/python/sfllm/serving/tokenizer_manager.py
@@ -6,6 +6,7 @@ from sfllm.engine.sequence import AbortSequence, DecodeSequence, RequestSequence
 from sfllm.engine.sampling_params import SamplingParams
 from sfllm.serving.req_protocol import GenerateReqInput
 from sfllm.engine.inference_engine import InferenceEngine
+from sfllm.engine.tokenizer import IncrementalDetokenizer
 from sfllm.server_args import set_global_server_args_for_scheduler
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ class TokenizerManager:
         self.tokenizer_input_queue = None
         self.tokenizer_output_queue = None
         self.ready_flag = multiprocessing.Value("b", False)
+        self.decode_states = {}
 
     def set_tokenizer_queues(self, input_queue, output_queue):
         self.tokenizer_input_queue = input_queue
@@ -95,6 +97,7 @@ class TokenizerManager:
             try:
                 out_sequence = self.tokenizer_input_queue.get()
                 if isinstance(out_sequence, AbortSequence):
+                    self.decode_states.pop(out_sequence.sequence_id, None)
                     self.inferengine_input_queue.put(out_sequence)
                 elif isinstance(out_sequence, RequestSequence):
                     out_sequence.init(self.tokenizer)
@@ -109,21 +112,29 @@ class TokenizerManager:
                     out_sequence.sampling_params.stop_token_sequences = tuple(
                         stop_token_sequences
                     )
+                    self.decode_states[out_sequence.sequence_id] = (
+                        IncrementalDetokenizer(self.tokenizer)
+                    )
                     self.inferengine_input_queue.put(out_sequence)
                 elif isinstance(out_sequence, list):
                     assert isinstance(out_sequence[0], DecodeSequence)
                     seq_outputs = {}
                     for seq in out_sequence:
-                        generated_text = self.tokenizer.decode(
-                            seq.tokens, skip_special_tokens=True
-                        )
+                        state = self.decode_states.get(seq.sequence_id)
+                        if state is None:
+                            continue  # Output already in flight when aborted.
+                        finished = not seq.status.is_active()
+                        generated_text = state.append(seq.tokens, finished)
+                        if finished:
+                            self.decode_states.pop(seq.sequence_id)
                         seq_outputs[seq.sequence_id] = {
                             "text": generated_text,
                             "output_ids": seq.tokens,
                             "completion_tokens": seq.completion_tokens,
                             "status": seq.status,
                         }
-                    self.tokenizer_output_queue.put(seq_outputs)
+                    if seq_outputs:
+                        self.tokenizer_output_queue.put(seq_outputs)
                 else:
                     raise ValueError("Unknown sequence type received in tokenizer_event_run_loop.")
             except Exception as e:


### PR DESCRIPTION
GSM8K accuracy:

| Model | Main (`0adea48`) | This PR (`cdd74e8`) | SGLang (`02d9b306`) |
|---|---:|---:|---:|
| Qwen3.5-4B | 86.43% (1140/1319) | 86.50% (1141/1319) | 86.81% (1145/1319) |
| Qwen3-4B | 86.81% (1145/1319) | 87.19% (1150/1319) | 86.35% (1139/1319) |

ShareGPT, measured on the current revision:

| Model | Completed | Output tokens | Duration (s) | Output tok/s | TTFT (ms) | TPOT (ms) |
|---|---:|---:|---:|---:|---:|---:|
| Qwen3.5-4B | 1000/1000 | 913,652 | 213.250 | 4284.42 | 109.08 | 5.403 |
| Qwen3-4B | 1000/1000 | 1,023,588 | 230.480 | 4441.12 | 210.75 | 5.155 |

Overlapping inference can overwrite queued output deltas before they are consumed, repeating or dropping returned text. Completion counts also include a pending token placeholder: a 1024-token request can report 1025. Separately, decoding each token in isolation corrupts characters whose UTF-8 bytes span several tokens.

Snapshot committed outputs before queue handoff, copy the tokenizer payload, and count committed positions. Use `tokenizers.decoders.DecodeStream` directly for serving and offline streaming; flush remaining text at completion and release per-request decoding state. Offline output also preserves terminal deltas and emits each request's delta once. Enable FA3 automatic split selection (`num_splits=0`) in both scheduler metadata and forward execution, using the existing changes from the working tree.

Based directly on main; no dependency on #25. The final diff changes three output-handling files and the two FA3 call sites and adds no custom decoder class or tests.

Validation on H100 NVL / BF16:

- Chinese and emoji HTTP output matches decoding the returned token IDs together. Offline streaming matches full decoding at each tested token limit, including incomplete final UTF-8 bytes.
- Five focused output-snapshot checks pass, covering delayed consumption, payload ownership, committed counts, terminal deltas, and offline completion. All 2638 final-revision GSM8K responses match full decoding of their returned token IDs, and their completion counts match those IDs. No request exceeds the configured output cap in either GSM8K or ShareGPT.
- GSM8K: all 1319 test questions, five demonstrations from the training split, greedy decoding, 512-token cap, server concurrency 32 / client concurrency 24. One training-split warmup is excluded; answers use normalized last-number matching. Native `/generate` streaming exercises the affected output path.


The fixed revision is `cdd74e8`; the baseline is main `0adea48`. These accuracy measurements do not establish token-by-token equivalence between separate inference runs.

<details>
<summary>Evaluation commands and records</summary>

Server, from the evaluated checkout:

```bash
PYTHONDONTWRITEBYTECODE=1 \
PYTHONPATH="$PWD/python:/workspace/sfllm/sfkernels/python" \
/workspace/sglang/.venv/bin/python python/sfllm/serving/app.py \
  --model-path /mnt/data/jicwen/work/Qwen3.5-4B \
  --port 8081 --dtype bfloat16 \
  --max-running-requests 32 --cuda-graph-max-bs 32 \
  --attention-backend fa3 --linear-attn-backend flashinfer --mem-fraction 0.7
```

ShareGPT uses 1000 requests, a 1024-token output cap, an 8192-token context filter, seed 1, streaming, and EOS stopping. Each server receives one excluded Unicode correctness request before the benchmark; the benchmark then runs its one excluded warmup request.

ShareGPT client:

```bash
PYTHONPATH="$PWD/python:/workspace/sfllm/sfkernels/python" \
/workspace/sglang/.venv/bin/python -m sfllm.serving.sgl_bench_seving \
  --backend sglang-native --host 127.0.0.1 --port 8081 \
  --model /mnt/data/jicwen/work/Qwen3.5-4B \
  --tokenizer /mnt/data/jicwen/work/Qwen3.5-4B \
  --dataset-name sharegpt \
  --dataset-path /mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json \
  --num-prompts 1000 --max-concurrency 24 --sharegpt-context-len 8192 \
  --sharegpt-output-len 1024 --disable-ignore-eos --seed 1 \
  --warmup-requests 1 --output-details --output-file results.jsonl
```

GSM8K client:

```bash
/workspace/sglang/.venv/bin/python \
  /tmp/sfllm-pr1-serving-fix.2dldw1tz/gsm8k_client.py \
  --output-dir /tmp/sfllm-pr1-serving-fix.2dldw1tz/final-evaluation/qwen35/gsm8k \
  --port 8081 --max-concurrency 24 --num-shots 5 --max-new-tokens 512
```

Qwen3-4B uses `/mnt/data/jicwen/work/Qwen3-4B` and the `final-evaluation/qwen3/gsm8k` output directory. Prompts contain the first five official GSM8K training examples followed by the test question; stop strings are `Question:`, `Assistant:`, and `<|separator|>`.

Evaluation client and official train/test data are retained under `/tmp/sfllm-pr1-serving-fix.2dldw1tz/`. Final-revision commands, commit IDs, responses, token IDs, and summaries are under `final-evaluation/`; baseline records are under `gsm8k/`.
SGLang reference (`02d9b306`), using the same checkpoints, prompts, sampling parameters, and client concurrency:

```bash
PATH="/workspace/sglang/.venv/bin:$PATH" \
PYTHONPATH=/workspace/sglang/python \
/workspace/sglang/.venv/bin/python -m sglang.launch_server \
  --model-path /mnt/data/jicwen/work/Qwen3.5-4B \
  --port 8081 --dtype bfloat16 --max-running-requests 32 \
  --cuda-graph-max-bs 32 --attention-backend fa3 \
  --linear-attn-backend flashinfer --mamba-ssm-dtype float32 \
  --mem-fraction-static 0.7
```

The SGLang client uses the same evaluation script with only the `output_ids` collector adapted to its cumulative streaming payload. Run `gsm8k_client_sglang.py` with the same arguments and an output directory under `sglang-gsm8k/` (Qwen3.5) or `sglang-gsm8k-qwen3/` (Qwen3). Qwen3-4B uses its model path and omits `--mamba-ssm-dtype`; both frameworks use FP32 SSM state for Qwen3.5.
</details>
