### PR TITLE
perf: accelerate EAGLE3 verification and honor generation EOS

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -40,7 +40,7 @@ Wait for `Application startup complete` and a successful health check, then run 
 
 ```bash
 curl --fail http://127.0.0.1:8081/health
-python -m sfllm.serving.sgl_bench_seving \
+python benchmark/bench_serving.py \
   --backend sglang-native --host 127.0.0.1 --port 8081 \
   --model "$BENCH_MODEL" --tokenizer "$BENCH_MODEL" \
   --dataset-name sharegpt --dataset-path "$BENCH_DATASET" \

--- a/benchmark/bench_serving.py
+++ b/benchmark/bench_serving.py
@@ -5,9 +5,9 @@
 Benchmark online serving with dynamic requests.
 
 Usage:
-python3 -m sglang.bench_serving --backend sglang --num-prompt 10
+python3 benchmark/bench_serving.py --backend sglang-native --num-prompts 10
 
-python3 -m sglang.bench_serving --backend sglang --dataset-name random --num-prompts 3000 --random-input 1024 --random-output 1024 --random-range-ratio 0.5
+python3 benchmark/bench_serving.py --backend sglang-native --dataset-name random --num-prompts 3000 --random-input 1024 --random-output 1024 --random-range-ratio 0.5
 """
 
 import argparse
@@ -1001,7 +1001,8 @@ def sample_sharegpt_requests(
                 add_generation_prompt=True,
                 tokenize=False,
             )
-            prompt = prompt.replace(tokenizer.bos_token, "")
+            if tokenizer.bos_token:
+                prompt = prompt.replace(tokenizer.bos_token, "")
 
         prompt_token_ids = tokenizer.encode(prompt)
         completion = dataset[i][1]

--- a/python/sfllm/kernels/extend_attention.py
+++ b/python/sfllm/kernels/extend_attention.py
@@ -416,8 +416,12 @@ def extend_attention_fwd(
         num_warps = 4
 
     else:
+        num_warps = 4 if Lk <= 64 else 8
         if _is_cuda and CUDA_CAPABILITY[0] >= 9:
-            if Lq <= 256:
+            if Lq == Lk == Lv == 128 and custom_mask is not None and max_len_extend <= 16:
+                BLOCK_M, BLOCK_N = (16, 64)
+                num_warps = 4
+            elif Lq <= 256:
                 BLOCK_M, BLOCK_N = (128, 64)
             else:
                 BLOCK_M, BLOCK_N = (32, 64)
@@ -439,8 +443,6 @@ def extend_attention_fwd(
                     BLOCK_M, BLOCK_N = (32, 64)
         else:
             BLOCK_M, BLOCK_N = (64, 64) if Lq <= 128 else (32, 32)
-
-        num_warps = 4 if Lk <= 64 else 8
 
     sm_scale = sm_scale or 1.0 / (Lq**0.5)
     batch_size, head_num = qo_indptr.shape[0] - 1, q_extend.shape[1]

--- a/python/sfllm/kernels/fa3_attention.py
+++ b/python/sfllm/kernels/fa3_attention.py
@@ -93,8 +93,10 @@ def fa3_attention_fwd(
     metadata,
     softmax_scale: float,
     causal: bool,
+    *,
+    return_softmax_lse: bool = False,
 ) -> torch.Tensor:
-    flash_attn_with_kvcache(
+    result = flash_attn_with_kvcache(
         q,
         k_buffer.view(k_buffer.shape[0], 1, k_buffer.shape[1], k_buffer.shape[2]),
         v_buffer.view(v_buffer.shape[0], 1, v_buffer.shape[1], v_buffer.shape[2]),
@@ -106,6 +108,9 @@ def fa3_attention_fwd(
         causal=causal,
         num_splits=0,
         scheduler_metadata=metadata.scheduler_metadata,
+        return_softmax_lse=return_softmax_lse,
         out=out,
     )
+    if return_softmax_lse:
+        return result
     return out.view(out.shape[0], -1)

--- a/python/sfllm/layers/fa3_attention.py
+++ b/python/sfllm/layers/fa3_attention.py
@@ -5,6 +5,7 @@ from sgl_kernel.flash_attn import get_scheduler_metadata
 
 from sfllm.engine.forward_params import ForwardBatch, ForwardMode
 from sfllm.kernels.fa3_attention import build_page_table, fa3_attention_fwd
+from sfllm.layers.verify_attention import verify_attention
 from sfllm.server_args import get_global_server_args
 
 
@@ -37,8 +38,10 @@ class FA3AttentionWorkspace:
         q: torch.Tensor,
         layer,
     ) -> FA3AttentionMetadata:
-        if forward_batch.custom_mask is not None:
-            raise NotImplementedError("FA3 does not support custom attention masks.")
+        is_tree_verify = (
+            forward_batch.forward_mode == ForwardMode.TARGET_VERIFY
+            and forward_batch.custom_mask is not None
+        )
 
         batch_size = forward_batch.kv_indptr.shape[0] - 1
         if batch_size > self.page_table.shape[0]:
@@ -70,7 +73,7 @@ class FA3AttentionWorkspace:
             qo_indptr,
             page_table,
             cache_seqlens,
-            append_query=not is_decode,
+            append_query=not is_decode and not is_tree_verify,
             prefix_window=(
                 layer.sliding_window_size
                 if forward_batch.forward_mode == ForwardMode.DRAFT_EXTEND else -1
@@ -87,7 +90,7 @@ class FA3AttentionWorkspace:
             qkv_dtype=q.dtype,
             cu_seqlens_q=qo_indptr,
             page_size=1,
-            causal=layer.is_causal,
+            causal=layer.is_causal and not is_tree_verify,
             num_splits=0,
         )
         return FA3AttentionMetadata(
@@ -112,8 +115,11 @@ class FA3AttentionBackend:
         self.workspace = None
         if layer_idx == 0:
             server_args = get_global_server_args()
+            max_batch_size = int(server_args.max_running_requests)
+            if server_args.speculative_algorithm == "eagle3":
+                max_batch_size *= server_args.speculative_eagle_topk
             self.workspace = FA3AttentionWorkspace(
-                int(server_args.cuda_graph_max_bs),
+                max_batch_size,
                 server_args.max_context_length
                 + server_args.speculative_num_draft_tokens,
                 torch.device("cuda"),
@@ -133,8 +139,16 @@ class FA3AttentionBackend:
             raise NotImplementedError(
                 f"FA3 does not support attention options: {sorted(kwargs)}."
             )
+        if forward_batch.forward_mode == ForwardMode.TARGET_VERIFY:
+            output = verify_attention(
+                q, k, v, layer, forward_batch, save_kv_cache, workspace=self.workspace
+            )
+            if output is not None:
+                return output
         if forward_batch.past_key_values is None:
             return torch.zeros_like(q)
+        if forward_batch.custom_mask is not None:
+            raise NotImplementedError("FA3 does not support custom attention masks.")
         if save_kv_cache:
             forward_batch.update(k, v, layer.layer_id)
 

--- a/python/sfllm/layers/verify_attention.py
+++ b/python/sfllm/layers/verify_attention.py
@@ -1,0 +1,102 @@
+"""EAGLE tree verification with FA3 prefix/suffix attention, as in SGLang."""
+
+import torch
+
+from sfllm.server_args import get_global_server_args
+
+try:
+    from sgl_kernel import merge_state_v2
+    from sgl_kernel.flash_attn import get_scheduler_metadata
+    from sfllm.kernels.fa3_attention import fa3_attention_fwd
+except ImportError:
+    merge_state_v2 = None
+
+
+FA3_VERIFY_AVAILABLE = (
+    merge_state_v2 is not None
+    and torch.version.cuda is not None
+    and torch.cuda.is_available()
+    and torch.cuda.get_device_capability()[0] == 9
+    and tuple(map(int, torch.version.cuda.split(".")[:2])) >= (12, 3)
+)
+
+
+def prepare_verify_attention(workspace, forward_batch, q, layer):
+    prefix = workspace.prepare(forward_batch, q, layer)
+    batch_size = prefix.cache_seqlens.shape[0]
+    width = prefix.max_query_len
+    if q.shape[0] != batch_size * width:
+        raise ValueError("Tree verification requires equal query counts per request.")
+
+    # Every query sees the common prefix and its own visible tree nodes.
+    offsets = torch.arange(width, device=q.device)
+    prefix_lens = prefix.cache_seqlens[:, None, None]
+    mask_indices = (
+        forward_batch.mask_indptr[:-1, None, None]
+        + offsets[None, :, None] * (prefix_lens + width)
+        + prefix_lens + offsets[None, None, :]
+    )
+    mask = forward_batch.custom_mask[mask_indices]
+    order = torch.where(mask, offsets, offsets + width).argsort(dim=-1)
+    page_table = (
+        forward_batch.out_cache_loc.view(batch_size, 1, width)
+        .expand(-1, width, -1).gather(2, order).reshape(-1, width).int()
+    )
+    cache_seqlens = mask.sum(dim=-1, dtype=torch.int32).flatten()
+    qo_indptr = torch.arange(q.shape[0] + 1, dtype=torch.int32, device=q.device)
+    scheduler = get_scheduler_metadata(
+        batch_size=q.shape[0],
+        max_seqlen_q=1,
+        max_seqlen_k=width,
+        num_heads=layer.tp_q_head_num,
+        num_heads_k=layer.tp_k_head_num,
+        headdim=layer.qk_head_dim,
+        cache_seqlens=cache_seqlens,
+        qkv_dtype=q.dtype,
+        cu_seqlens_q=qo_indptr,
+        page_size=1,
+        causal=False,
+        num_splits=0,
+    )
+    suffix = type(prefix)(page_table, cache_seqlens, scheduler, qo_indptr, 1)
+    return prefix, suffix
+
+
+def verify_attention(q, k, v, layer, forward_batch, save_kv_cache=True, *, workspace):
+    if (
+        not FA3_VERIFY_AVAILABLE
+        or get_global_server_args().speculative_algorithm != "eagle3"
+        or forward_batch.custom_mask is None
+        or q.dtype not in (torch.float16, torch.bfloat16)
+        or layer.qk_head_dim != layer.v_head_dim
+        or layer.qk_head_dim > 256
+        or layer.qk_head_dim % 8
+        or layer.sliding_window_size > 0
+        or layer.logit_cap
+        or layer.is_cross_attention
+    ):
+        return None
+    if forward_batch.past_key_values is None:
+        return torch.zeros_like(q)
+    if save_kv_cache:
+        forward_batch.update(k, v, layer.layer_id)
+    if workspace is not None:
+        forward_batch._verify_attention_metadata = prepare_verify_attention(
+            workspace, forward_batch, q, layer
+        )
+    prefix, suffix = forward_batch._verify_attention_metadata
+    query = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+    k_buffer, v_buffer = forward_batch.past_key_values[layer.layer_id]
+    prefix_out, prefix_lse, *_ = fa3_attention_fwd(
+        query, torch.empty_like(query), k_buffer, v_buffer, prefix, layer.scaling,
+        False, return_softmax_lse=True,
+    )
+    suffix_out, suffix_lse, *_ = fa3_attention_fwd(
+        query, torch.empty_like(query), k_buffer, v_buffer, suffix, layer.scaling,
+        False, return_softmax_lse=True,
+    )
+    output, _ = merge_state_v2(
+        prefix_out, prefix_lse.T.contiguous(),
+        suffix_out, suffix_lse.T.contiguous(), v_merged=prefix_out,
+    )
+    return output.view(q.shape)

--- a/python/sfllm/serving/tokenizer_manager.py
+++ b/python/sfllm/serving/tokenizer_manager.py
@@ -1,5 +1,6 @@
 import logging
 from tokenizers.decoders import DecodeStream
+from transformers import AutoConfig, AutoTokenizer, GenerationConfig
 import torch.multiprocessing as multiprocessing
 from sfllm.engine.sequence import AbortSequence, DecodeSequence, RequestSequence
 from sfllm.engine.sampling_params import SamplingParams
@@ -28,8 +29,6 @@ class TokenizerManager:
         self.tokenizer_output_queue = output_queue
 
     def load_tokenizer(self):
-        from transformers import AutoConfig, AutoTokenizer
-
         self.tokenizer = AutoTokenizer.from_pretrained(self.server_args.model_path, trust_remote_code=True,)
         if self.tokenizer.pad_token is None:
             self.tokenizer.pad_token = self.tokenizer.eos_token
@@ -42,6 +41,15 @@ class TokenizerManager:
         self.eos_token_ids = frozenset(model_eos or ())
         if self.tokenizer.eos_token_id is not None:
             self.eos_token_ids |= {self.tokenizer.eos_token_id}
+        try:
+            generation_eos = GenerationConfig.from_pretrained(
+                self.server_args.model_path
+            ).eos_token_id
+        except OSError:
+            generation_eos = None
+        if isinstance(generation_eos, int):
+            generation_eos = (generation_eos,)
+        self.eos_token_ids |= frozenset(generation_eos or ())
 
     @staticmethod
     def inferengine_event_run_loop(self):


### PR DESCRIPTION
EAGLE3 tree verification now uses FA3 for the shared prefix and visible tree nodes, then merges the attention states. Reduce the Triton tile for short masked queries and reuse existing FA3 metadata storage.

Also honor EOS IDs from `generation_config.json` (Qwen3-4B's `151643` was omitted), move the serving benchmark to `benchmark/bench_serving.py`, and handle tokenizers without a BOS token when applying chat templates.

**Validation:** NVIDIA H100 NVL, Qwen3-4B BF16, EAGLE3 **4/4/8**, FA3, server **32** / client **24**, CUDA Graphs and overlap enabled.

| GSM8K test — 1319 questions, 5-shot, greedy, max 512 tokens | Correct | Accuracy |
| --- | ---: | ---: |
| This commit (`da4ec70`), freshly measured | 1145/1319 | 86.81% |
| SGLang Qwen3-4B, prior non-speculative reference; identical prompts | 1139/1319 | 86.35% |

GSM8K: 1319 successful requests, 0 unparseable answers, no output-length overruns or token-count mismatches; 50.102 s, 158481 output tokens.

| ShareGPT, 1000 successful requests each | Input tokens | Output tokens | Duration | Output tok/s | Acclen |
| --- | ---: | ---: | ---: | ---: | ---: |
| Raw prompts | 308695 | 1022768 | 176.322 s | **5800.56** | 2.91 |
| Chat template, default thinking | 309293 | 951283 | 189.127 s | **5029.86** | 2.50 |

Raw output lengths: 11, 883, 946, and 997 × 1024. Chat lengths: 78–1024; 182 finish below the cap, 818 reach it. Both runs have zero tokens after EOS and zero reported-length mismatches. Acclen is the median logged acceptance window. Template filtering selects a different workload, so the two rows are not a direct speed comparison.

ShareGPT measurements precede the final metadata-argument cleanup and script relocation. GPU/CUDA Graph regression outputs for that cleanup are bitexact against the prior implementation; ordinary causal verification and unsupported-mask rejection also pass. **Generation across speculative and non-speculative modes is not bitexact**; the EOS fix does not resolve those numerical differences.

<details>
<summary>Server and client commands</summary>

Run from the repository root in the existing sfllm environment (`/workspace/sglang/.venv/bin/python`):

```bash
export BENCH_MODEL=/mnt/data/jicwen/work/Qwen3-4B
export BENCH_DRAFT=/mnt/data/jicwen/work/Qwen3-4B_eagle3
export BENCH_DATASET=/mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json

python python/sfllm/serving/app.py \
  --model-path "$BENCH_MODEL" --port 8081 --dtype bfloat16 \
  --max-running-requests 32 --cuda-graph-max-bs 32 \
  --attention-backend fa3 --linear-attn-backend flashinfer --mem-fraction 0.7 \
  --speculative-algorithm eagle3 --speculative-draft-model-path "$BENCH_DRAFT" \
  --speculative-num-steps 4 --speculative-eagle-topk 4 --speculative-num-draft-tokens 8
```

Wait for `Application startup complete` and a successful health check. In a second terminal:

```bash
curl --fail http://127.0.0.1:8081/health

python /tmp/sfllm-pr1-serving-fix.2dldw1tz/gsm8k_client.py \
  --output-dir /tmp/gsm8k-verify --port 8081 \
  --max-concurrency 24 --num-shots 5 --max-new-tokens 512

python benchmark/bench_serving.py \
  --backend sglang-native --host 127.0.0.1 --port 8081 \
  --model "$BENCH_MODEL" --tokenizer "$BENCH_MODEL" \
  --dataset-name sharegpt --dataset-path "$BENCH_DATASET" \
  --num-prompts 1000 --max-concurrency 24 \
  --sharegpt-context-len 8192 --sharegpt-output-len 1024 \
  --seed 1 --warmup-requests 1 --disable-ignore-eos \
  --output-details --output-file /tmp/sharegpt-1000.jsonl
```

For the chat-template workload, append `--apply-chat-template` and use a separate output file. ShareGPT uses streaming, temperature 0, and excludes warmup from timing. GSM8K uses the first five training examples, all 1319 test questions, last-number answer extraction, and stops `Question:`, `Assistant:`, `<|separator|>`.

Local evidence (exact commands, source hashes, summaries and raw token IDs):
- Fresh GSM8K: `/tmp/sfllm-pr-verify-gsm8k.t6aku_ik`.
- Raw ShareGPT1000: `/tmp/sfllm-eos-validated.bmn3k0n_`.
- Chat ShareGPT1000 and three-mode EOS controls: `/tmp/sfllm-chat-eos-all-modes.wnk393ha`.
- Metadata regression: `/tmp/sfllm-prefix-inference.lwoyvp4c`.

</details>
