### PR TITLE
feat: support ModelOpt FP8 for Qwen3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ python python/sfllm/serving/app.py \
   --dtype float16
 ```
 
+**Qwen3.5 per-tensor FP8:**
+
+Export a calibrated Hugging Face checkpoint with NVIDIA ModelOpt's
+`FP8_DEFAULT_CFG` and `export_hf_checkpoint`, then serve it with:
+
+```bash
+python python/sfllm/serving/app.py \
+  --model /path/to/Qwen3.5-4B-FP8 --dtype bfloat16 --quantization fp8 \
+  --max-running-requests 32 --cuda-graph-max-bs 32 --port 8081
+```
+
+The exported quantization config is detected automatically, so `--quantization fp8`
+is optional. Both `config.json` and legacy `hf_quant_config.json` metadata are
+supported. ModelOpt's excluded layers retain BF16, including the GDN a/b projections;
+FP8 KV-cache quantization is not supported.
+
 ### 2. Test the API
 
 **Chat Completions (Streaming)**

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -54,15 +54,15 @@ The client uses streaming and temperature 0, respects EOS, and excludes the warm
 
 ## Qwen3.5-4B per-tensor FP8
 
-Measured 2026-09-08 on H100 NVL, server 32 / client 24, 1000 successful ShareGPT requests in each run. Both use FA3, FlashInfer GDN prefill, Triton GDN decode, and BF16 activations outside the quantized linear layers.
+Measured 2026-09-08 on H100 NVL, server 32 / client 24, 1000 successful ShareGPT requests in each run. Both use FA3, FlashInfer GDN prefill/decode, and BF16 activations outside the quantized linear layers.
 
 | Weights | Input tokens | Output tokens | Duration | Output tok/s | GSM8K (5-shot, max 512) |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| BF16 | 318819 | 912805 | 211.882 s | 4308.08 | 1147/1319 (86.96%) |
-| ModelOpt FP8 | 318819 | 915747 | 184.371 s | 4966.86 | 1093/1319 (82.87%) |
+| BF16 | 318819 | 909944 | 209.882 s | 4335.50 | 1151/1319 (87.26%) |
+| ModelOpt FP8 | 318819 | 913127 | 184.061 s | 4960.99 | 1100/1319 (83.40%) |
 
-FP8 improves measured output throughput by 15.29%, with a 4.09 percentage-point GSM8K loss for this checkpoint. Output lengths range from 2 to 1024; 229 BF16 requests and 238 FP8 requests finish below the cap.
+FP8 improves measured output throughput by 14.43%, with a 3.87 percentage-point GSM8K loss for this checkpoint. Output lengths range from 2 to 1024; 238 BF16 requests and 233 FP8 requests finish below the cap.
 
 The same FP8 checkpoint scores **1095/1319 (83.02%)** on SGLang (`b5c9b68`), using identical GSM8K prompts and generation limits, FA3, FlashInfer GDN, and FP32 recurrent state. The accuracy loss is also present in this reference run.
 
-Quantization: ModelOpt 0.46.0, `FP8_DEFAULT_CFG`, 128 ShareGPT calibration samples truncated to 512 tokens. Use the server/client commands above, adding `--linear-attn-prefill-backend flashinfer --linear-attn-decode-backend triton` to the server. For FP8, point `BENCH_MODEL` to the ModelOpt export; quantization is detected from its config.
+Quantization: ModelOpt 0.46.0, `FP8_DEFAULT_CFG`, 128 ShareGPT calibration samples truncated to 512 tokens. Use the server/client commands above. For FP8, point `BENCH_MODEL` to the ModelOpt export; quantization is detected from its config.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -51,3 +51,18 @@ python benchmark/bench_serving.py \
 ```
 
 The client uses streaming and temperature 0, respects EOS, and excludes the warmup request from timing. Wait for the final summary; detailed results are saved in the JSONL file.
+
+## Qwen3.5-4B per-tensor FP8
+
+Measured 2026-09-08 on H100 NVL, server 32 / client 24, 1000 successful ShareGPT requests in each run. Both use FA3, FlashInfer GDN prefill, Triton GDN decode, and BF16 activations outside the quantized linear layers.
+
+| Weights | Input tokens | Output tokens | Duration | Output tok/s | GSM8K (5-shot, max 512) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| BF16 | 318819 | 912805 | 211.882 s | 4308.08 | 1147/1319 (86.96%) |
+| ModelOpt FP8 | 318819 | 915747 | 184.371 s | 4966.86 | 1093/1319 (82.87%) |
+
+FP8 improves measured output throughput by 15.29%, with a 4.09 percentage-point GSM8K loss for this checkpoint. Output lengths range from 2 to 1024; 229 BF16 requests and 238 FP8 requests finish below the cap.
+
+The same FP8 checkpoint scores **1095/1319 (83.02%)** on SGLang (`b5c9b68`), using identical GSM8K prompts and generation limits, FA3, FlashInfer GDN, and FP32 recurrent state. The accuracy loss is also present in this reference run.
+
+Quantization: ModelOpt 0.46.0, `FP8_DEFAULT_CFG`, 128 ShareGPT calibration samples truncated to 512 tokens. Use the server/client commands above, adding `--linear-attn-prefill-backend flashinfer --linear-attn-decode-backend triton` to the server. For FP8, point `BENCH_MODEL` to the ModelOpt export; quantization is detected from its config.

--- a/python/sfllm/layers/linear.py
+++ b/python/sfllm/layers/linear.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 WEIGHT_LOADER_V2_SUPPORTED = [
     "UnquantizedLinearMethod",
+    "Fp8LinearMethod",
     "CompressedTensorsLinearMethod",
 ]
 

--- a/python/sfllm/layers/quantization/fp8.py
+++ b/python/sfllm/layers/quantization/fp8.py
@@ -57,6 +57,7 @@ class Fp8Config(QuantizationConfig):
         ignored_layers: Optional[List[str]] = None,
         weight_block_size: List[int] = None,
     ) -> None:
+        super().__init__()
         self.is_checkpoint_fp8_serialized = is_checkpoint_fp8_serialized
         if is_checkpoint_fp8_serialized:
             logger.info("Detected fp8 checkpoint.")
@@ -97,6 +98,17 @@ class Fp8Config(QuantizationConfig):
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "Fp8Config":
+        config = config.get("quantization", config)
+        if "quant_algo" in config or config.get("quant_method") == "modelopt":
+            if config.get("quant_algo") != "FP8":
+                raise ValueError("Only ModelOpt per-tensor FP8 checkpoints are supported")
+            if config.get("kv_cache_quant_algo") or config.get("kv_cache_scheme"):
+                raise ValueError("ModelOpt FP8 KV-cache quantization is not supported")
+            return cls(
+                is_checkpoint_fp8_serialized=True,
+                activation_scheme="static",
+                ignored_layers=config.get("ignore", config.get("exclude_modules")),
+            )
         quant_method = cls.get_from_keys(config, ["quant_method"])
         is_checkpoint_fp8_serialized = "fp8" in quant_method
         activation_scheme = cls.get_from_keys(config, ["activation_scheme"])
@@ -119,7 +131,7 @@ class Fp8Config(QuantizationConfig):
     ) -> Optional[QuantizeMethodBase]:
         from sfllm.layers.linear import LinearBase
         if isinstance(layer, LinearBase):
-            if is_layer_skipped(prefix, self.ignored_layers):
+            if is_layer_skipped(prefix, self.ignored_layers, self.packed_modules_mapping):
                 return UnquantizedLinearMethod()
             return Fp8LinearMethod(self)
         return None
@@ -266,6 +278,11 @@ class Fp8LinearMethod(LinearMethodBase):
                 layer.register_parameter("input_scale", None)
 
     def process_weights_after_loading(self, layer: Module) -> None:
+        if self.quant_config.is_checkpoint_fp8_serialized and not self.block_quant:
+            for name in ("weight_scale", "input_scale"):
+                scale = getattr(layer, name, None)
+                if scale is not None and not torch.all(torch.isfinite(scale) & (scale > 0)):
+                    raise ValueError(f"Missing or invalid FP8 {name} in {layer.prefix}")
         if self.block_quant:
             # If ROCm, normalize the weights and scales to e4m3fnuz
             if _is_fp8_fnuz:

--- a/python/sfllm/layers/quantization/utils.py
+++ b/python/sfllm/layers/quantization/utils.py
@@ -1,4 +1,5 @@
 import torch
+from fnmatch import fnmatchcase
 from typing import Callable, List, Mapping, Union, Tuple
 from sfllm.layers.quantization.fp8_kernel import scaled_fp8_quant
 from types import MappingProxyType
@@ -111,7 +112,8 @@ def is_layer_skipped(
         is_skipped = None
         for shard_prefix in shard_prefixes:
             is_shard_skipped = any(
-                ignored in shard_prefix for ignored in ignored_layers
+                ignored in shard_prefix or fnmatchcase(shard_prefix, ignored)
+                for ignored in ignored_layers
             )
 
             if is_skipped is None:
@@ -123,7 +125,10 @@ def is_layer_skipped(
                     "to have the same precision."
                 )
     else:
-        is_skipped = any(ignored in prefix for ignored in ignored_layers)
+        is_skipped = any(
+            ignored in prefix or fnmatchcase(prefix, ignored)
+            for ignored in ignored_layers
+        )
         if "gate_up_proj" in prefix:
             prefix_gate = prefix.replace("gate_up_proj", "gate_proj")
             prefix_up = prefix.replace("gate_up_proj", "up_proj")

--- a/python/sfllm/model_loader/model_loader.py
+++ b/python/sfllm/model_loader/model_loader.py
@@ -1,4 +1,5 @@
 from contextlib import ContextDecorator
+import json
 import torch
 import logging
 import transformers
@@ -15,6 +16,7 @@ from typing import (
 )
 from sfllm.model_loader.model_config import ModelConfig
 from sfllm.layers.quantization import QuantizationConfig, get_quantization_config
+from sfllm.model_loader.weight_utils import _get_resolved_base_dir
 logger = logging.getLogger(__name__)
 
 
@@ -54,33 +56,36 @@ def get_quant_config(
     model_config,
     packed_modules_mapping: Dict[str, List[str]],
     remap_prefix: Dict[str, str] | None = None,
-) -> QuantizationConfig:
-    quant_cls = get_quantization_config(model_config.quantization)
-    possible_config_filenames = quant_cls.get_config_filenames()
-    # If the quantization config is not found, use the default config.
-    if not possible_config_filenames:
-        return quant_cls()
-    return quant_cls.from_config(
-        {
-            "model_config": model_config,
-            "packed_modules_mapping": packed_modules_mapping,
-            "remap_prefix": remap_prefix,
-        }
-    )
-
-
-def _get_quantization_config(
-    model_config,
-    packed_modules_mapping: Dict[str, List[str]],
-    remap_prefix: Dict[str, str] | None = None,
 ) -> Optional[QuantizationConfig]:
-    """Get the quantization config."""
-    if model_config.quantization is not None:
-        quant_config = get_quant_config(
-            model_config, packed_modules_mapping, remap_prefix
-        )
-        return quant_config
-    return None
+    config = getattr(model_config.hf_config, "quantization_config", None)
+    if config is None:
+        config = getattr(model_config.hf_config.get_text_config(), "quantization_config", None)
+    if config is None:
+        config_path = _get_resolved_base_dir(model_config.model_path, "hf_quant_config.json")
+        if config_path is not None:
+            with open(config_path) as f:
+                config = json.load(f)
+
+    checkpoint_method = None
+    if config is not None:
+        checkpoint_method = config.get("quant_method")
+        if checkpoint_method == "modelopt" or "quantization" in config or "quant_algo" in config:
+            checkpoint_method = "fp8"
+    method = model_config.quantization
+    if method is not None and checkpoint_method is not None and method != checkpoint_method:
+        raise ValueError(f"Requested {method} quantization, but checkpoint uses {checkpoint_method}")
+    method = method or checkpoint_method
+    if method is None:
+        return None
+    quant_cls = get_quantization_config(method)
+    quant_config = quant_cls.from_config(config) if config is not None else quant_cls()
+    quant_config.packed_modules_mapping = packed_modules_mapping
+    for source, target in (remap_prefix or {}).items():
+        quant_config.ignored_layers = [
+            name.replace(source, target, 1) for name in quant_config.ignored_layers
+        ]
+    return quant_config
+
 
 def initialize_model(model_name:str, dtype:str="auto", quantization:Optional[str]=None):
     """
@@ -124,7 +129,7 @@ def load_model(model_config: ModelConfig):
     model_class, _ = get_model_architecture(model_config.hf_config)
     packed_modules_mapping = getattr(model_class, "packed_modules_mapping", {})
     remap_prefix = getattr(model_class, "remap_prefix", None)
-    quant_config = _get_quantization_config(model_config, packed_modules_mapping, remap_prefix)
+    quant_config = get_quant_config(model_config, packed_modules_mapping, remap_prefix)
     with TorchDefaultReset(model_config.dtype, device="cuda"):
         model = model_class(model_config.hf_config, quant_config=quant_config)
         weight_iterator = _load_check_point(model_config.model_path)

--- a/python/sfllm/models/qwen3_5.py
+++ b/python/sfllm/models/qwen3_5.py
@@ -23,7 +23,7 @@ from sfllm.layers.linear import (
     RowParallelLinear,
 )
 from sfllm.layers.logits_processor import LogitsProcessor
-from sfllm.layers.quantization import QuantizationConfig
+from sfllm.layers.quantization import Fp8Config, QuantizationConfig
 from sfllm.layers.radix_attention import RadixAttention
 from sfllm.layers.rotary_embedding import get_rope
 from sfllm.model_loader.model_config import get_pool_index_layers
@@ -57,21 +57,25 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         self.conv_states = conv_states
         self.ssm_states = ssm_states
         self.state_indices = state_indices
+        self.quant_config = quant_config
 
-        self.in_proj_qkvzba = MergedColumnParallelLinear(
-            self.hidden_size,
-            [
-                self.key_dim,
-                self.key_dim,
-                self.value_dim,
-                self.value_dim,
-                self.num_v_heads,
-                self.num_v_heads,
-            ],
-            bias=False,
-            quant_config=quant_config,
-            prefix=add_prefix("in_proj_qkvzba", prefix),
-        )
+        qkvz_sizes = [self.key_dim, self.key_dim, self.value_dim, self.value_dim]
+        ba_sizes = [self.num_v_heads, self.num_v_heads]
+        if quant_config is None:
+            self.in_proj_qkvzba = MergedColumnParallelLinear(
+                self.hidden_size, qkvz_sizes + ba_sizes, bias=False,
+                prefix=add_prefix("in_proj_qkvzba", prefix),
+            )
+        else:
+            # ModelOpt keeps the recurrent gates in BF16 by default.
+            self.in_proj_qkvz = MergedColumnParallelLinear(
+                self.hidden_size, qkvz_sizes, bias=False, quant_config=quant_config,
+                prefix=add_prefix("in_proj_qkvz", prefix),
+            )
+            self.in_proj_ba = MergedColumnParallelLinear(
+                self.hidden_size, ba_sizes, bias=False, quant_config=quant_config,
+                prefix=add_prefix("in_proj_ba", prefix),
+            )
         self.conv_weight = nn.Parameter(
             torch.empty(self.conv_dim, 1, self.conv_kernel_size), requires_grad=False
         )
@@ -117,10 +121,14 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         )
         state_indices = self.state_indices[:num_sequences]
 
-        projected, _ = self.in_proj_qkvzba(hidden_states)
-        projected_qkvz, projected_ba = projected.split(
-            (self.conv_dim + self.value_dim, self.num_v_heads * 2), dim=-1
-        )
+        if self.quant_config is None:
+            projected, _ = self.in_proj_qkvzba(hidden_states)
+            projected_qkvz, projected_ba = projected.split(
+                (self.conv_dim + self.value_dim, self.num_v_heads * 2), dim=-1
+            )
+        else:
+            projected_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            projected_ba, _ = self.in_proj_ba(hidden_states)
 
         common = dict(
             conv_weight=self.conv_weight.view(self.conv_dim, self.conv_kernel_size),
@@ -479,9 +487,12 @@ class Qwen3_5Model(nn.Module):
 class Qwen3_5ForConditionalGeneration(nn.Module, HasBatchState):
     """Text-only serving view of a dense Qwen3.5 multimodal checkpoint."""
 
+    remap_prefix = {"model.language_model.": "model."}
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
         "in_proj_qkvzba": [
             "in_proj_qkv",
             "in_proj_z",
@@ -497,10 +508,13 @@ class Qwen3_5ForConditionalGeneration(nn.Module, HasBatchState):
         prefix: str = "",
     ) -> None:
         super().__init__()
-        if quant_config is not None:
-            raise ValueError("Initial Qwen3.5 support is BF16-only")
+        if quant_config is not None and (
+            not isinstance(quant_config, Fp8Config) or quant_config.weight_block_size is not None
+        ):
+            raise ValueError("Qwen3.5 only supports per-tensor FP8 quantization")
         text_config = config.text_config
         self.config = text_config
+        self.quant_config = quant_config
         self.model = Qwen3_5Model(text_config, quant_config, add_prefix("model", prefix))
         self.lm_head = self.model.embed_tokens if text_config.tie_word_embeddings else ReplicatedLinear(
             text_config.hidden_size, text_config.vocab_size, bias=False
@@ -529,6 +543,9 @@ class Qwen3_5ForConditionalGeneration(nn.Module, HasBatchState):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params = dict(self.named_parameters())
         loaded = set()
+        qkvz_proj = "in_proj_qkvz" if self.quant_config is not None else "in_proj_qkvzba"
+        ba_proj = "in_proj_ba" if self.quant_config is not None else "in_proj_qkvzba"
+        ba_offset = 0 if self.quant_config is not None else 4
 
         for checkpoint_name, loaded_weight in weights:
             if checkpoint_name.startswith("model.visual.") or checkpoint_name.startswith("mtp."):
@@ -542,7 +559,7 @@ class Qwen3_5ForConditionalGeneration(nn.Module, HasBatchState):
                 name = name.replace(".linear_attn.conv1d.weight", ".linear_attn.conv_weight")
 
             mappings = []
-            if ".linear_attn.in_proj_qkv.weight" in name:
+            if ".linear_attn.in_proj_qkv." in name:
                 chunks = loaded_weight.split(
                     [
                         self.config.linear_num_key_heads * self.config.linear_key_head_dim,
@@ -550,15 +567,15 @@ class Qwen3_5ForConditionalGeneration(nn.Module, HasBatchState):
                         self.config.linear_num_value_heads * self.config.linear_value_head_dim,
                     ],
                     dim=0,
-                )
-                target = name.replace("in_proj_qkv", "in_proj_qkvzba")
+                ) if name.endswith(".weight") else [loaded_weight] * 3
+                target = name.replace("in_proj_qkv", qkvz_proj)
                 mappings = [(target, chunk, idx) for idx, chunk in enumerate(chunks)]
-            elif ".linear_attn.in_proj_z.weight" in name:
-                mappings = [(name.replace("in_proj_z", "in_proj_qkvzba"), loaded_weight, 3)]
-            elif ".linear_attn.in_proj_b.weight" in name:
-                mappings = [(name.replace("in_proj_b", "in_proj_qkvzba"), loaded_weight, 4)]
-            elif ".linear_attn.in_proj_a.weight" in name:
-                mappings = [(name.replace("in_proj_a", "in_proj_qkvzba"), loaded_weight, 5)]
+            elif ".linear_attn.in_proj_z." in name:
+                mappings = [(name.replace("in_proj_z", qkvz_proj), loaded_weight, 3)]
+            elif ".linear_attn.in_proj_b." in name:
+                mappings = [(name.replace("in_proj_b", ba_proj), loaded_weight, ba_offset)]
+            elif ".linear_attn.in_proj_a." in name:
+                mappings = [(name.replace("in_proj_a", ba_proj), loaded_weight, ba_offset + 1)]
             else:
                 stacked = [
                     ("qkv_proj", "q_proj", "q"),


### PR DESCRIPTION
Support Qwen3.5 per-tensor FP8 checkpoints exported by NVIDIA ModelOpt through the existing `fp8` path, with automatic metadata detection. Load packed weights/scales and respect excluded BF16 layers, including GDN a/b projections. Unquantized BF16 retains the fused qkvzba projection; FP8 KV-cache and block quantization remain unsupported for Qwen3.5.

H100 NVL, CUDA 13.0, **FA3 attention + FlashInfer GDN prefill**. GDN decode is specified per row below. ShareGPT: 1000/1000 successful requests, server 32 / client 24, 318819 input tokens, seed 1, output cap 1024, EOS enabled, no profiler. GSM8K: 1319 test questions, 5-shot, greedy, max 512 tokens.

| Weights | GDN decode | Output tokens | Duration | Output tok/s | GSM8K |
| --- | --- | ---: | ---: | ---: | ---: |
| BF16 | FlashInfer | 909944 | 209.882 s | 4335.50 | 1151/1319 (87.26%) |
| ModelOpt FP8 | Triton | 915747 | 184.371 s | 4966.86 | 1093/1319 (82.87%) |

The table shows the highest measured output throughput for each model in the current-code runs, with the decode backend and its corresponding GSM8K score. Output lengths range from 2 to 1024; mean lengths are BF16 909.944 and FP8 915.747, with 238 requests below the cap in each run. All GSM8K requests succeeded with no outputs above the limit.

SGLang `b5c9b68`, using the same FP8 checkpoint, identical GSM8K prompts, FA3, FlashInfer GDN and FP32 recurrent state, scores **1095/1319 (83.02%)**.

Export: ModelOpt 0.46.0, `FP8_DEFAULT_CFG`, 128 ShareGPT calibration samples, max 512 tokens, seed 0. Python syntax and `git diff --check` pass.

<details>
<summary>Server and client commands</summary>

Run from the repository root; use these variables in both terminals. For FP8, set `BENCH_MODEL=/mnt/data/jicwen/work/Qwen3.5-4B-ModelOpt-FP8`; quantization is detected from its config. Set `GDN_DECODE=triton` for the FP8/Triton row.

```bash
export BENCH_MODEL=/mnt/data/jicwen/work/Qwen3.5-4B
export BENCH_DATASET=/mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json
export GDN_DECODE=flashinfer
export PYTHONPATH="$PWD/python:$PWD/sfkernels/python"

/workspace/sglang/.venv/bin/python python/sfllm/serving/app.py \
  --model-path "$BENCH_MODEL" --port 8081 --dtype bfloat16 \
  --max-running-requests 32 --cuda-graph-max-bs 32 \
  --attention-backend fa3 --linear-attn-prefill-backend flashinfer \
  --linear-attn-decode-backend "$GDN_DECODE" --mem-fraction 0.7
```

After startup, wait for `/health` to return 200, then run the client:

```bash
curl --fail http://127.0.0.1:8081/health
/workspace/sglang/.venv/bin/python benchmark/bench_serving.py \
  --backend sglang-native --host 127.0.0.1 --port 8081 \
  --model "$BENCH_MODEL" --tokenizer "$BENCH_MODEL" \
  --dataset-name sharegpt --dataset-path "$BENCH_DATASET" \
  --num-prompts 1000 --max-concurrency 24 \
  --sharegpt-context-len 8192 --sharegpt-output-len 1024 \
  --seed 1 --warmup-requests 1 --disable-ignore-eos \
  --output-details --output-file /tmp/sharegpt-1000.jsonl
```

The GSM8K client uses the same server configuration:

```bash
/workspace/sglang/.venv/bin/python \
  /tmp/sfllm-pr1-serving-fix.2dldw1tz/gsm8k_client.py \
  --output-dir /tmp/gsm8k --port 8081 --max-concurrency 24 \
  --num-shots 5 --max-new-tokens 512
```

Raw results and exact commands are retained locally in `/tmp/sfllm-qwen35-modelopt/` (FP8/Triton), `/tmp/sfllm-fp8-flashinfer-validation.ov3kq62b/` (FlashInfer validation), and `/tmp/sfllm-bf16-flashinfer1000.8jaqg_6s/` (BF16 ShareGPT). All serving source files were unchanged during evaluation.

</details>
