### PR TITLE
feat: support Qwen3.5 dynamic FP8 with fused quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ python python/sfllm/serving/app.py \
   --dtype float16
 ```
 
-**Qwen3.5 per-tensor FP8:**
+**Qwen3.5 FP8:**
 
 Export a calibrated Hugging Face checkpoint with NVIDIA ModelOpt's
 `FP8_DEFAULT_CFG` and `export_hf_checkpoint`, then serve it with:
@@ -84,6 +84,10 @@ The exported quantization config is detected automatically, so `--quantization f
 is optional. Both `config.json` and legacy `hf_quant_config.json` metadata are
 supported. ModelOpt's excluded layers retain BF16, including the GDN a/b projections;
 FP8 KV-cache quantization is not supported.
+
+Qwen3.5 `compressed-tensors` exports using `FP8_DYNAMIC` (per-channel weights,
+per-token dynamic activations) are also detected automatically. Use the same
+command with `--dtype bfloat16`, including for exports whose config declares float32.
 
 ### 2. Test the API
 

--- a/python/sfllm/engine/scheduler.py
+++ b/python/sfllm/engine/scheduler.py
@@ -52,7 +52,7 @@ class Scheduler:
         self.running_queue = queue.Queue()
         
         self.max_context_length = server_args.max_context_length
-        self.max_prefill_tokens = min(self.max_context_length, 8192)
+        self.max_prefill_tokens = self.max_context_length
         self.max_running_req = server_args.max_running_requests
         # Stable slots are shared by overlap token handoff and model-owned state.
         self.free_request_indices = deque(range(self.max_running_req))

--- a/python/sfllm/layers/activations.py
+++ b/python/sfllm/layers/activations.py
@@ -22,20 +22,25 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from sfllm.layers.op_base import CustomOp
+from sfllm.layers.quantization.fp8_kernel import silu_and_mul_quant_fp8
 from sfllm.model_loader.weight_utils import set_weight_attrs
 
 logger = logging.getLogger(__name__)
 
 
 class SiluAndMul(CustomOp):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, quant_method=None):
+        super().__init__()
+        self.output_quantization = quant_method
+        self.fp8_output = quant_method is not None and quant_method.input_dtype is not None
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         d = x.shape[-1] // 2
         return F.silu(x[..., :d]) * x[..., d:]
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+        if self.fp8_output:
+            return silu_and_mul_quant_fp8(x, input_scale=self.output_quantization.input_scale)
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)

--- a/python/sfllm/layers/layernorm.py
+++ b/python/sfllm/layers/layernorm.py
@@ -26,6 +26,7 @@ except ImportError:
     _flashinfer_norm = None
 
 from sfllm.layers.op_base import CustomOp
+from sfllm.layers.quantization.fp8_kernel import gemma_rmsnorm_quant_fp8
 logger = logging.getLogger(__name__)
 
 class RMSNorm(CustomOp):
@@ -136,10 +137,14 @@ class GemmaRMSNorm(CustomOp):
         self,
         hidden_size: int,
         eps: float = 1e-6,
+        quant_methods: tuple = (),
     ) -> None:
         super().__init__()
         self.weight = nn.Parameter(torch.zeros(hidden_size), requires_grad=False)
         self.variance_epsilon = eps
+        self.quant_methods = quant_methods
+        self.output_dtypes = tuple(method.input_dtype for method in quant_methods)
+        self.fp8_output = any(dtype is not None for dtype in self.output_dtypes)
 
     def forward_native(
         self,
@@ -156,6 +161,8 @@ class GemmaRMSNorm(CustomOp):
         x = x * torch.rsqrt(variance + self.variance_epsilon)
         x = x * (1.0 + self.weight.float())
         x = x.to(orig_dtype)
+        if len(self.quant_methods) > 1:
+            x = (x,) * len(self.quant_methods)
         return x if residual is None else (x, residual)
 
     def forward_cuda(
@@ -165,21 +172,37 @@ class GemmaRMSNorm(CustomOp):
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         # Both CUDA paths keep normalization and (1 + weight) in FP32.
         # Residual addition is fused into the same kernel.
-        if _flashinfer_norm is None:
-            out = torch.empty_like(x)
-            sf_kernel.rmsnorm(
-                out, x, self.weight, self.variance_epsilon, residual,
-                gemma_style=True,
+        if self.fp8_output:
+            output = gemma_rmsnorm_quant_fp8(
+                x, weight=self.weight, residual=residual,
+                eps=self.variance_epsilon,
+                output_dtypes=self.output_dtypes,
+                input_scales=tuple(method.input_scale for method in self.quant_methods),
             )
-            return out if residual is None else (out, residual)
-        if residual is None:
-            return _flashinfer_norm.gemma_rmsnorm(
+            return output if residual is None else (output, residual)
+        if (
+            _flashinfer_norm is None or self.weight.dtype != x.dtype
+            or x.stride(-1) != 1 or self.weight.stride(0) != 1
+            or (residual is not None and (
+                residual.dtype != x.dtype or residual.stride(-1) != 1
+            ))
+        ):
+            out = gemma_rmsnorm_quant_fp8(
+                x, self.weight, residual, self.variance_epsilon,
+                output_dtypes=(None,),
+            )
+        elif residual is None:
+            out = _flashinfer_norm.gemma_rmsnorm(
                 x, self.weight, self.variance_epsilon
             )
-        _flashinfer_norm.gemma_fused_add_rmsnorm(
-            x, residual, self.weight, self.variance_epsilon
-        )
-        return x, residual
+        else:
+            _flashinfer_norm.gemma_fused_add_rmsnorm(
+                x, residual, self.weight, self.variance_epsilon
+            )
+            out = x
+        if len(self.quant_methods) > 1:
+            out = (out,) * len(self.quant_methods)
+        return out if residual is None else (out, residual)
 
 class Gemma3RMSNorm(CustomOp):
     def __init__(self, dim: int, eps: float = 1e-6):

--- a/python/sfllm/layers/quantization/base_config.py
+++ b/python/sfllm/layers/quantization/base_config.py
@@ -52,6 +52,10 @@ class QuantizeMethodBase(ABC):
 class LinearMethodBase(QuantizeMethodBase):
     """Base class for different (maybe quantized) linear methods."""
 
+    # Input format for a fused producer; None preserves the activation dtype.
+    input_dtype: torch.dtype | None = None
+    input_scale: torch.Tensor | None = None
+
     @abstractmethod
     def create_weights(
         self,

--- a/python/sfllm/layers/quantization/fp8.py
+++ b/python/sfllm/layers/quantization/fp8.py
@@ -16,27 +16,27 @@ from sfllm.layers.quantization.base_config import (
 from sfllm.utils import get_tensor_model_parallel_world_size,get_tensor_model_parallel_rank
 
 from sfllm.layers.quantization.fp8_kernel import (
-    per_token_group_quant_fp8,
+    fp8_dtype,
+    triton_scaled_mm,
 )
 from sfllm.layers.quantization.fp8_utils import (
     apply_fp8_linear,
-    cutlass_fp8_supported,
-    dispatch_w8a8_block_fp8_linear,
+    fp8_scaled_mm,
+    torch_scaled_mm,
+    triton_w8a8_block_fp8_linear,
     input_to_float8,
     normalize_e4m3fn_to_e4m3fnuz,
-    requant_weight_ue8m0_inplace,
     _is_fp8_fnuz,
 )
 
-from sfllm.layers.quantization.unquant import UnquantizedLinearMethod
 from sfllm.layers.quantization.utils import (
-    convert_to_channelwise,
     is_layer_skipped,
     requantize_with_max_scale,
 )
 
 from sfllm.layers.parameter import (
     BlockQuantScaleParameter,
+    ChannelQuantScaleParameter,
     ModelWeightParameter,
     PerTensorScaleParameter,
 )
@@ -56,6 +56,7 @@ class Fp8Config(QuantizationConfig):
         activation_scheme: str = "dynamic",
         ignored_layers: Optional[List[str]] = None,
         weight_block_size: List[int] = None,
+        weight_strategy: str = "tensor",
     ) -> None:
         super().__init__()
         self.is_checkpoint_fp8_serialized = is_checkpoint_fp8_serialized
@@ -79,6 +80,7 @@ class Fp8Config(QuantizationConfig):
                     f"The block-wise quantization only supports dynamic activation scheme for now, but got {activation_scheme} activation scheme."
                 )
         self.weight_block_size = weight_block_size
+        self.weight_strategy = weight_strategy
 
     @classmethod
     def get_name(cls) -> str:
@@ -99,6 +101,40 @@ class Fp8Config(QuantizationConfig):
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "Fp8Config":
         config = config.get("quantization", config)
+        if config.get("quant_method") == "compressed-tensors":
+            groups = list(config.get("config_groups", {}).values())
+            if (
+                config.get("format") != "float-quantized"
+                or config.get("quantization_status") != "compressed"
+                or len(groups) != 1
+                or groups[0].get("targets") != ["Linear"]
+                or groups[0].get("output_activations") is not None
+                or config.get("kv_cache_scheme")
+                or config.get("sparsity_config")
+                or config.get("transform_config")
+            ):
+                raise ValueError("Only compressed-tensors FP8_DYNAMIC linear quantization is supported")
+            for name, strategy, dynamic in (
+                ("weights", "channel", False),
+                ("input_activations", "token", True),
+            ):
+                args = groups[0].get(name) or {}
+                if (
+                    args.get("type") != "float"
+                    or args.get("num_bits") != 8
+                    or args.get("strategy") != strategy
+                    or args.get("dynamic") is not dynamic
+                    or args.get("symmetric") is not True
+                    or args.get("group_size") is not None
+                    or args.get("block_structure") is not None
+                ):
+                    raise ValueError(f"Unsupported compressed-tensors FP8_DYNAMIC {name}: {args}")
+            return cls(
+                is_checkpoint_fp8_serialized=True,
+                activation_scheme="dynamic",
+                ignored_layers=config.get("ignore"),
+                weight_strategy="channel",
+            )
         if "quant_algo" in config or config.get("quant_method") == "modelopt":
             if config.get("quant_algo") != "FP8":
                 raise ValueError("Only ModelOpt per-tensor FP8 checkpoints are supported")
@@ -129,7 +165,7 @@ class Fp8Config(QuantizationConfig):
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> Optional[QuantizeMethodBase]:
-        from sfllm.layers.linear import LinearBase
+        from sfllm.layers.linear import LinearBase, UnquantizedLinearMethod
         if isinstance(layer, LinearBase):
             if is_layer_skipped(prefix, self.ignored_layers, self.packed_modules_mapping):
                 return UnquantizedLinearMethod()
@@ -141,32 +177,23 @@ class Fp8Config(QuantizationConfig):
 
 
 class Fp8LinearMethod(LinearMethodBase):
-    """Linear method for FP8.
-    Supports loading FP8 checkpoints with static weight scale and
-    dynamic/static activation scale.
+    """FP8 linear weights with tensor, channel, or block scales.
 
-    Also supports loading quantized FP16/BF16 model checkpoints with dynamic
-    activation scaling. The weight scaling factor will be initialized after
-    the model weights are loaded.
-
-    Limitations:
-    1. Only support per-tensor quantization due to torch._scaled_mm support.
-    2. Only support float8_e4m3fn data type due to the limitation of
-       torch._scaled_mm (https://github.com/pytorch/pytorch/blob/2e48b39603411a41c5025efbe52f89560b827825/aten/src/ATen/native/cuda/Blas.cpp#L854-L856)
-
-    Args:
-        quant_config: The quantization config.
+    Fused producers may pass (FP8 activations, scales) for non-block weights.
     """
 
     def __init__(self, quant_config: Union[Fp8Config, ]):
         self.quant_config = quant_config
-        self.cutlass_fp8_supported = cutlass_fp8_supported()
 
-        # For GPUs that lack FP8 hardware support, we can leverage the Marlin
-        # kernel for fast weight-only FP8 quantization
-        self.use_marlin = False
         self.block_quant = self.quant_config.weight_block_size is not None
-        self.w8a8_block_fp8_linear = dispatch_w8a8_block_fp8_linear()
+        self.input_dtype = None if self.block_quant else fp8_dtype
+        self.scaled_mm = triton_scaled_mm
+        if current_platform.is_cuda() and current_platform.has_device_capability((8, 9)):
+            # Preserve the original accumulation for scalar activation/weight scales.
+            if quant_config.activation_scheme == "static" and quant_config.weight_strategy == "tensor":
+                self.scaled_mm = torch_scaled_mm
+            elif fp8_scaled_mm is not None:
+                self.scaled_mm = fp8_scaled_mm
 
     def create_weights(
         self,
@@ -180,6 +207,11 @@ class Fp8LinearMethod(LinearMethodBase):
     ):
         output_size_per_partition = sum(output_partition_sizes)
         weight_loader = extra_weight_attrs.get("weight_loader")
+        # Native GEMMs require aligned dimensions and BF16/FP16 output.
+        output_alignment = 16 if self.scaled_mm is torch_scaled_mm else 8
+        if (input_size_per_partition % 16 or output_size_per_partition % output_alignment
+                or params_dtype not in (torch.float16, torch.bfloat16)):
+            self.scaled_mm = triton_scaled_mm
 
         tp_size = get_tensor_model_parallel_world_size()
         if self.block_quant:
@@ -234,10 +266,7 @@ class Fp8LinearMethod(LinearMethodBase):
         if self.quant_config.is_checkpoint_fp8_serialized:
             # WEIGHT SCALE
             if self.block_quant:
-                if hasattr(self.quant_config, "activation_scheme"):
-                    assert self.quant_config.activation_scheme == "dynamic"
-                elif hasattr(self.quant_config, "linear_activation_scheme"):
-                    assert self.quant_config.linear_activation_scheme == "dynamic"
+                assert self.quant_config.activation_scheme == "dynamic"
                 scale = BlockQuantScaleParameter(
                     data=torch.empty(
                         (output_size_per_partition + block_n - 1) // block_n,
@@ -248,9 +277,19 @@ class Fp8LinearMethod(LinearMethodBase):
                     output_dim=0,
                     weight_loader=weight_loader,
                 )
-                scale.format_ue8m0 = False
                 scale[:] = torch.finfo(torch.float32).min
                 layer.register_parameter("weight_scale_inv", scale)
+            elif self.quant_config.weight_strategy == "channel":
+                scale = ChannelQuantScaleParameter(
+                    data=torch.full(
+                        (output_size_per_partition, 1),
+                        torch.finfo(torch.float32).min,
+                        dtype=torch.float32,
+                    ),
+                    output_dim=0,
+                    weight_loader=weight_loader,
+                )
+                layer.register_parameter("weight_scale", scale)
             else:
                 scale = PerTensorScaleParameter(
                     data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
@@ -260,13 +299,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 layer.register_parameter("weight_scale", scale)
 
             # INPUT ACTIVATION SCALE
-            if (
-                hasattr(self.quant_config, "activation_scheme")
-                and self.quant_config.activation_scheme == "static"
-            ) or (
-                hasattr(self.quant_config, "linear_activation_scheme")
-                and self.quant_config.linear_activation_scheme == "static"
-            ):
+            if self.quant_config.activation_scheme == "static":
                 scale = PerTensorScaleParameter(
                     data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
                     weight_loader=weight_loader,
@@ -294,32 +327,6 @@ class Fp8LinearMethod(LinearMethodBase):
                 )
                 layer.input_scale = None
             else:
-                # For fp8 linear weights run with deepgemm, the weights and scales need be requantized to ue8m0
-                from sfllm.layers.quantization.fp8_utils import (
-                    deepgemm_w8a8_block_fp8_linear_with_fallback,
-                )
-                from sfllm.model_loader.utils import (
-                    should_deepgemm_weight_requant_ue8m0,
-                )
-
-                if (
-                    should_deepgemm_weight_requant_ue8m0(
-                        weight_block_size=getattr(
-                            self.quant_config, "weight_block_size", None
-                        ),
-                    )
-                    and (
-                        self.w8a8_block_fp8_linear
-                        is deepgemm_w8a8_block_fp8_linear_with_fallback
-                    )
-                    and (not layer.weight_scale_inv.format_ue8m0)
-                ):
-                    requant_weight_ue8m0_inplace(
-                        layer.weight,
-                        layer.weight_scale_inv,
-                        self.quant_config.weight_block_size,
-                    )
-                    layer.weight_scale_inv.format_ue8m0 = True
                 weight, weight_scale = layer.weight.data, layer.weight_scale_inv.data
 
             layer.weight.data = weight.data
@@ -329,16 +336,7 @@ class Fp8LinearMethod(LinearMethodBase):
 
             # If checkpoint not serialized fp8, quantize the weights.
             if not self.quant_config.is_checkpoint_fp8_serialized:
-                if self.cutlass_fp8_supported or self.use_marlin:
-                    # apply per-channel quantization default as
-                    # cutlass sgl-kernel and marlin only support per-channel scale
-                    qweight, weight_scale = per_token_group_quant_fp8(
-                        layer.weight, layer.weight.shape[-1]
-                    )
-                    weight_scale = weight_scale.t().contiguous()
-                else:
-                    # per-tensor quantization
-                    qweight, weight_scale = input_to_float8(layer.weight)
+                qweight, weight_scale = input_to_float8(layer.weight)
 
                 # Update the layer with the new values.
                 layer.weight = Parameter(qweight.t(), requires_grad=False)
@@ -351,41 +349,24 @@ class Fp8LinearMethod(LinearMethodBase):
                 layer.weight_scale = Parameter(
                     layer.weight_scale.data, requires_grad=False
                 )
-                if (
-                    hasattr(self.quant_config, "activation_scheme")
-                    and self.quant_config.activation_scheme == "static"
-                ) or (
-                    hasattr(self.quant_config, "linear_activation_scheme")
-                    and self.quant_config.linear_activation_scheme == "static"
-                ):
-                    layer.input_scale = Parameter(
-                        layer.input_scale.data, requires_grad=False
-                    )
-
-                # cutlass sgl-kernel and marlin only support per-channel scale
-                if self.cutlass_fp8_supported or self.use_marlin:
-                    weight = layer.weight
-                    weight_scale = convert_to_channelwise(
-                        layer.weight_scale, layer.logical_widths
-                    )
-                else:
-                    # Dequant -> Quant with max scale so we can run per tensor.
-                    weight = layer.weight
-                    weight_scale = layer.weight_scale
-                    # If ROCm, normalize the weights and scales to e4m3fnuz
-                    if _is_fp8_fnuz:
-                        weight, weight_scale, input_scale = (
-                            normalize_e4m3fn_to_e4m3fnuz(
-                                weight=weight,
-                                weight_scale=weight_scale,
-                                input_scale=layer.input_scale,
-                            )
+                weight = layer.weight
+                weight_scale = layer.weight_scale
+                # If ROCm, normalize the weights and scales to e4m3fnuz
+                if _is_fp8_fnuz:
+                    weight, weight_scale, input_scale = (
+                        normalize_e4m3fn_to_e4m3fnuz(
+                            weight=weight,
+                            weight_scale=weight_scale,
+                            input_scale=layer.input_scale,
                         )
-                        if input_scale is not None:
-                            layer.input_scale = Parameter(
-                                input_scale, requires_grad=False
-                            )
+                    )
+                    if input_scale is not None:
+                        layer.input_scale = Parameter(
+                            input_scale, requires_grad=False
+                        )
 
+                if self.quant_config.weight_strategy != "channel":
+                    # Merge per-tensor scales; preserve serialized channel scales.
                     weight_scale, weight = requantize_with_max_scale(
                         weight=weight,
                         weight_scale=weight_scale,
@@ -395,23 +376,19 @@ class Fp8LinearMethod(LinearMethodBase):
                 # Update layer with new values.
                 layer.weight = Parameter(weight.t(), requires_grad=False)
                 layer.weight_scale = Parameter(weight_scale, requires_grad=False)
-                if (
-                    hasattr(self.quant_config, "activation_scheme")
-                    and self.quant_config.activation_scheme == "static"
-                ) or (
-                    hasattr(self.quant_config, "linear_activation_scheme")
-                    and self.quant_config.linear_activation_scheme == "static"
-                ):
+                if self.quant_config.activation_scheme == "static":
                     layer.input_scale = Parameter(
                         layer.input_scale.max(), requires_grad=False
                     )
 
-        # if self.use_marlin:
-        #     if self.block_quant:
-        #         layer.weight_block_size = self.quant_config.weight_block_size
-        #     prepare_fp8_layer_for_marlin(layer, not self.block_quant)
-        #     # Activations not quantized for marlin.
-        #     del layer.input_scale
+        if not self.block_quant:
+            self.input_scale = layer.input_scale
+            if self.scaled_mm is fp8_scaled_mm and layer.weight_scale.numel() == 1:
+                # SGL GEMM accepts scalar activation scales but needs one weight scale per column.
+                layer.weight_scale = Parameter(
+                    layer.weight_scale.expand(layer.weight.shape[1], 1).contiguous(),
+                    requires_grad=False,
+                )
 
     def apply(
         self,
@@ -419,29 +396,8 @@ class Fp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if self.use_marlin:
-            return apply_fp8_marlin_linear(
-                input=x,
-                weight=layer.weight,
-                weight_scale=layer.weight_scale,
-                workspace=layer.workspace,
-                size_n=layer.output_size_per_partition,
-                size_k=layer.input_size_per_partition,
-                bias=bias,
-            )
-
         if self.block_quant:
-            if isinstance(x, tuple):
-                return self.w8a8_block_fp8_linear(
-                    input=x[0],
-                    weight=layer.weight,
-                    block_size=self.quant_config.weight_block_size,
-                    weight_scale=layer.weight_scale_inv,
-                    input_scale=x[1],
-                    bias=bias,
-                )
-
-            return self.w8a8_block_fp8_linear(
+            return triton_w8a8_block_fp8_linear(
                 input=x,
                 weight=layer.weight,
                 block_size=self.quant_config.weight_block_size,
@@ -450,12 +406,18 @@ class Fp8LinearMethod(LinearMethodBase):
                 bias=bias,
             )
 
+        if isinstance(x, tuple):
+            quantized, scale = x
+            return self.scaled_mm(
+                quantized, layer.weight, scale, layer.weight_scale,
+                layer.params_dtype, bias,
+            )
+
         return apply_fp8_linear(
             input=x,
             weight=layer.weight,
             weight_scale=layer.weight_scale,
             input_scale=layer.input_scale,
             bias=bias,
-            cutlass_fp8_supported=self.cutlass_fp8_supported,
-            use_per_token_if_dynamic=False,
+            scaled_mm=self.scaled_mm,
         )

--- a/python/sfllm/layers/quantization/fp8_kernel.py
+++ b/python/sfllm/layers/quantization/fp8_kernel.py
@@ -19,19 +19,19 @@ import os
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple
 
+from sfllm.utils import get_bool_env_var
 from sfllm.utils.platform import current_platform
 
 import torch
 import triton
 import triton.language as tl
-# from sglang.srt.layers import deep_gemm_wrapper
-from sfllm.utils import (
-    direct_register_custom_op,
-)
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
 
 _is_hip = current_platform.is_hip()
 _is_cuda = current_platform.is_cuda()
 _is_cpu = False
+_native_fp8_dot = not _is_cuda or current_platform.has_device_capability((8, 9))
 
 def ceil_div(x: int, y: int) -> int:
     return (x + y - 1) // y
@@ -40,40 +40,10 @@ def ceil_align(x: int, y: int) -> int:
     return ceil_div(x, y) * y
 
 
-def get_bool_env_var(name: str, default: str = "false") -> bool:
-    # FIXME: move your environment variable to sglang.srt.environ
-    value = os.getenv(name, default)
-    value = value.lower()
-
-    truthy_values = ("true", "1")
-    falsy_values = ("false", "0")
-
-    if (value not in truthy_values) and (value not in falsy_values):
-        if value not in _warned_bool_env_var_keys:
-            logger.warning(
-                f"get_bool_env_var({name}) see non-understandable value={value} and treat as false"
-            )
-        _warned_bool_env_var_keys.add(value)
-
-    return value in truthy_values
-
-def supports_custom_op() -> bool:
-    return hasattr(torch.library, "custom_op")
-
 if _is_cuda:
     import sf_kernel
     sgl_per_tensor_quant_fp8 = torch.ops.sfkernels.sgl_per_tensor_quant_fp8
     sgl_per_token_quant_fp8 = torch.ops.sfkernels.sgl_per_token_quant_fp8
-    # Temporary
-    try:
-        from sgl_kernel import sgl_per_token_group_quant_8bit
-
-        enable_sgl_per_token_group_quant_8bit = True
-    except ImportError:
-        # from sgl_kernel import sgl_per_token_group_quant_fp8
-        sgl_per_token_group_quant_fp8 = None
-
-        enable_sgl_per_token_group_quant_8bit = False
 
 if _is_hip:
     try:
@@ -99,32 +69,6 @@ else:
     fp8_dtype = torch.float8_e4m3fn
     fp8_max = torch.finfo(fp8_dtype).max
 fp8_min = -fp8_max
-
-if supports_custom_op() and False:
-    def deep_gemm_fp8_fp8_bf16_nt(
-        A: torch.Tensor,
-        As: torch.Tensor,
-        B: torch.Tensor,
-        Bs: torch.Tensor,
-        C: torch.Tensor,
-    ) -> None:
-        deep_gemm_wrapper.gemm_nt_f8f8bf16((A, As), (B, Bs), C)
-
-    def deep_gemm_fp8_fp8_bf16_nt_fake(
-        A: torch.Tensor,
-        As: torch.Tensor,
-        B: torch.Tensor,
-        Bs: torch.Tensor,
-        C: torch.Tensor,
-    ) -> None:
-        return
-
-    direct_register_custom_op(
-        op_name="deep_gemm_fp8_fp8_bf16_nt",
-        op_func=deep_gemm_fp8_fp8_bf16_nt,
-        mutates_args=["C"],
-        fake_impl=deep_gemm_fp8_fp8_bf16_nt_fake,
-    )
 
 
 @triton.jit
@@ -332,113 +276,6 @@ def _per_token_group_quant_8bit_raw(
 per_token_group_quant_fp8 = _per_token_group_quant_8bit_raw
 
 
-def _per_token_group_quant_8bit_fuse_silu_and_mul(
-    x: torch.Tensor,
-    group_size: int,
-    dst_dtype: torch.dtype,
-    column_major_scales: bool,
-    scale_tma_aligned: bool,
-    scale_ue8m0: bool,
-    masked_m: Optional[torch.Tensor],
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    # Another way to implement (can be used in e.g. comparison tests)
-    # from sgl_kernel import silu_and_mul
-    # x_after_silu_and_mul = silu_and_mul(x)
-    # return per_token_group_quant_fp8(
-    #     x_after_silu_and_mul,
-    #     group_size=group_size,
-    #     eps=eps,
-    #     column_major_scales=column_major_scales,
-    #     scale_tma_aligned=scale_tma_aligned,
-    #     scale_ue8m0=scale_ue8m0,
-    # )
-
-    from deep_gemm import transform_sf_into_required_layout
-
-    from sglang.srt.layers.moe.ep_moe.kernels import silu_and_mul_masked_post_quant_fwd
-
-    assert column_major_scales
-    assert scale_tma_aligned
-    assert scale_ue8m0
-
-    needs_unsqueeze = x.dim() == 2
-    if needs_unsqueeze:
-        num_tokens, _ = x.shape
-        x = x.unsqueeze(0)
-        assert masked_m is None
-        masked_m = torch.tensor([num_tokens], device=x.device, dtype=torch.int32)
-
-    # Use `zeros` for easier testing
-    output = torch.zeros(
-        (*x.shape[:-1], x.shape[-1] // 2),
-        device=x.device,
-        dtype=dst_dtype,
-    )
-    # Use `zeros` for easier testing
-    output_scale_for_kernel = torch.zeros(
-        (*x.shape[:-1], x.shape[-1] // 2 // group_size),
-        device=x.device,
-        dtype=torch.float32,
-    )
-    silu_and_mul_masked_post_quant_fwd(
-        input=x,
-        output=output,
-        output_scale=output_scale_for_kernel,
-        quant_group_size=group_size,
-        masked_m=masked_m,
-        scale_ue8m0=scale_ue8m0,
-    )
-
-    assert group_size == 128
-    output_scale = transform_sf_into_required_layout(
-        output_scale_for_kernel,
-        num_groups=output.shape[0],
-        mn=output.shape[-2],
-        k=output.shape[-1],
-        recipe=(1, group_size, group_size),
-        is_sfa=True,
-    )
-
-    if needs_unsqueeze:
-        output = output.squeeze(0)
-        output_scale = output_scale.squeeze(0)
-
-    return output, output_scale
-
-
-def per_token_group_quant_8bit(
-    x: torch.Tensor,
-    group_size: int,
-    dst_dtype: torch.dtype,
-    eps: float = 1e-10,
-    column_major_scales: bool = False,
-    scale_tma_aligned: bool = False,
-    scale_ue8m0: bool = False,
-    fuse_silu_and_mul: bool = False,
-    masked_m: Optional[torch.Tensor] = None,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    if fuse_silu_and_mul:
-        return _per_token_group_quant_8bit_fuse_silu_and_mul(
-            x=x,
-            group_size=group_size,
-            dst_dtype=dst_dtype,
-            column_major_scales=column_major_scales,
-            scale_tma_aligned=scale_tma_aligned,
-            scale_ue8m0=scale_ue8m0,
-            masked_m=masked_m,
-        )
-    else:
-        return _per_token_group_quant_8bit_raw(
-            x=x,
-            group_size=group_size,
-            eps=eps,
-            column_major_scales=column_major_scales,
-            scale_tma_aligned=scale_tma_aligned,
-            scale_ue8m0=scale_ue8m0,
-            dtype=dst_dtype,
-        )
-
-
 def create_per_token_group_quant_fp8_output_scale(
     x_shape,
     device,
@@ -483,100 +320,128 @@ def create_per_token_group_quant_fp8_output_scale(
         )
 
 
-def sglang_per_token_group_quant_fp8(
-    x: torch.Tensor,
-    group_size: int,
-    eps: float = 1e-10,
-    column_major_scales: bool = False,
-    scale_tma_aligned: bool = False,
-    scale_ue8m0: bool = False,
-    fuse_silu_and_mul: bool = False,
-    masked_m: Optional[torch.Tensor] = None,
-    enable_v2: Optional[bool] = None,
+@gluon.jit
+def _norm_activation_fp8_kernel(
+    X, W, R, Gate, Out, Scale,
+    x_strides: gl.constexpr, residual_strides: gl.constexpr,
+    gate_strides: gl.constexpr, weight_stride: gl.constexpr,
+    heads: gl.constexpr, width: gl.constexpr, eps: gl.constexpr,
+    GEMMA: gl.constexpr, SILU_MUL: gl.constexpr,
+    BLOCK_H: gl.constexpr, BLOCK_D: gl.constexpr,
+    STATIC_SCALE: gl.constexpr, FP8_MAX: gl.constexpr,
 ):
-    assert (
-        x.shape[-1] % group_size == 0
-    ), "the last dimension of `x` cannot be divisible by `group_size`"
-    assert x.is_contiguous(), "`x` is not contiguous"
-
-    out_shape = (*x.shape[:-1], x.shape[-1] // (2 if fuse_silu_and_mul else 1))
-
-    x_q = torch.empty(out_shape, device=x.device, dtype=fp8_dtype)
-    x_s = create_per_token_group_quant_fp8_output_scale(
-        x_shape=out_shape,
-        device=x.device,
-        group_size=group_size,
-        column_major_scales=column_major_scales,
-        scale_tma_aligned=scale_tma_aligned,
-        scale_ue8m0=scale_ue8m0,
-    )
-
-    if x.shape[0] > 0:
-        # Temporary
-        if enable_sgl_per_token_group_quant_8bit:
-            sgl_per_token_group_quant_8bit(
-                x,
-                x_q,
-                x_s,
-                group_size,
-                eps,
-                fp8_min,
-                fp8_max,
-                scale_ue8m0,
-                fuse_silu_and_mul,
-                masked_m,
-                enable_v2=enable_v2,
-            )
+    row = gl.program_id(0)
+    if heads > 1:
+        layout: gl.constexpr = gl.BlockedLayout([1, 4], [1, 32], [gl.num_warps(), 1], [1, 0])
+    else:
+        layout: gl.constexpr = gl.BlockedLayout([1, 4], [1, 32], [1, gl.num_warps()], [1, 0])
+    h = gl.arange(0, BLOCK_H, layout=gl.SliceLayout(1, layout))
+    d = gl.arange(0, BLOCK_D, layout=gl.SliceLayout(0, layout))
+    mask = (h[:, None] < heads) & (d[None, :] < width)
+    offsets = h[:, None] * width + d[None, :]
+    x_offsets = row * x_strides[0] + h[:, None] * x_strides[1] + d[None, :] * x_strides[2]
+    x = gl.load(X + x_offsets,
+                mask=mask, other=0).to(gl.float32)
+    if R is not None:
+        residual_offsets = (row * residual_strides[0] + h[:, None] * residual_strides[1]
+                            + d[None, :] * residual_strides[2])
+        x += gl.load(R + residual_offsets, mask=mask, other=0).to(gl.float32)
+        gl.store(R + residual_offsets, x, mask=mask)
+    if W is not None:
+        inv_rms = gl.rsqrt(gl.sum(x * x, axis=1) / width + eps)
+        weight = gl.load(W + d * weight_stride, mask=d < width, other=0).to(gl.float32)
+        x = x * inv_rms[:, None] * (weight[None, :] + GEMMA)
+    if SILU_MUL:
+        up = gl.load(X + x_offsets + width * x_strides[2], mask=mask, other=0).to(gl.float32)
+        x = x / (1.0 + gl.exp(-x)) * up
+    if Gate is not None:
+        gate = gl.load(Gate + row * gate_strides[0] + h[:, None] * gate_strides[1]
+                       + d[None, :] * gate_strides[2],
+                       mask=mask, other=0).to(gl.float32)
+        if W is not None:
+            x *= gate / (1.0 + gl.exp(-gate))
         else:
-            assert not enable_v2
-            sgl_per_token_group_quant_fp8(
-                x, x_q, x_s, group_size, eps, fp8_min, fp8_max, scale_ue8m0
-            )
+            x *= 1.0 / (1.0 + gl.exp(-gate))
+    # Preserve the producer's BF16/FP16 rounding before quantization.
+    x = gl.where(mask, x.to(X.dtype.element_ty).to(gl.float32), 0.0)
+    for i in gl.static_range(len(Out)):
+        value = x
+        if Scale[i] is not None:
+            if STATIC_SCALE[i]:
+                scale = gl.load(Scale[i])
+            else:
+                amax = gl.max(gl.reshape(gl.abs(x), (BLOCK_H * BLOCK_D,)), axis=0)
+                scale = gl.div_rn(amax, FP8_MAX)
+                gl.store(Scale[i] + row, scale)
+            # Static quantization uses the same reciprocal as static_quant_fp8.
+            inv_scale = 1.0 / scale if STATIC_SCALE[i] else gl.where(scale == 0, 0.0, gl.div_rn(1.0, scale))
+            value = gl.minimum(gl.maximum(value * inv_scale, -FP8_MAX), FP8_MAX)
+        gl.store(Out[i] + row * heads * width + offsets, value, mask=mask)
 
-    return x_q, x_s
 
-
-# TODO maybe unify int8 and fp8 code later
-def sglang_per_token_group_quant_8bit(
-    x: torch.Tensor,
-    group_size: int,
-    dst_dtype: torch.dtype,
-    eps: float = 1e-10,
-    column_major_scales: bool = False,
-    scale_tma_aligned: bool = False,
-    scale_ue8m0: bool = False,
-    fuse_silu_and_mul: bool = False,
-    masked_m: Optional[torch.Tensor] = None,
-    enable_v2: Optional[bool] = None,
+def _launch_fp8_kernel(
+    x: torch.Tensor, *, weight=None, residual=None, gate=None,
+    eps: float = 1e-6, gemma: bool = False, silu_mul: bool = False,
+    output_dtypes=(fp8_dtype,), input_scales=(None,),
 ):
-    from sglang.srt.layers.quantization.int8_kernel import (
-        sglang_per_token_group_quant_int8,
+    """Produce each requested FP8 or original-precision output in one kernel."""
+    heads = x.shape[1] if x.ndim == 3 else (gate.shape[1] if gate is not None and gate.ndim == 3 else 1)
+    width = x.shape[-1] // (2 if silu_mul else 1) // (heads if x.ndim == 2 else 1)
+    outputs = tuple(
+        torch.empty((x.shape[0], heads * width), device=x.device, dtype=dtype or x.dtype)
+        for dtype in output_dtypes
     )
-
-    if dst_dtype == torch.int8:
-        assert not column_major_scales
-        assert not scale_tma_aligned
-        assert not fuse_silu_and_mul
-        assert masked_m is None
-        return sglang_per_token_group_quant_int8(
-            x=x,
-            group_size=group_size,
-            eps=eps,
-            dtype=dst_dtype,
-            enable_v2=enable_v2,
-        )
-
-    return sglang_per_token_group_quant_fp8(
-        x=x,
-        group_size=group_size,
-        eps=eps,
-        column_major_scales=column_major_scales,
-        scale_tma_aligned=scale_tma_aligned,
-        scale_ue8m0=scale_ue8m0,
-        fuse_silu_and_mul=fuse_silu_and_mul,
-        masked_m=masked_m,
-        enable_v2=enable_v2,
+    scales = tuple(
+        (scale if scale is not None else torch.empty((x.shape[0], 1), device=x.device, dtype=torch.float32))
+        if dtype is not None else None
+        for dtype, scale in zip(output_dtypes, input_scales)
     )
+    strides = tuple(
+        (t.stride(0), t.stride(1) if t.ndim == 3 else width * t.stride(-1), t.stride(-1))
+        if t is not None else (0, 0, 0)
+        for t in (x, residual, gate)
+    )
+    num_warps = 4 if heads * width <= 4096 else 8
+    _norm_activation_fp8_kernel[(x.shape[0],)](
+        x, weight, residual, gate, outputs, scales,
+        *strides, weight.stride(0) if weight is not None else 0,
+        heads, width, eps, gemma, silu_mul,
+        triton.next_power_of_2(heads), triton.next_power_of_2(width),
+        tuple(scale is not None for scale in input_scales), fp8_max,
+        num_warps=num_warps,
+        enable_fp_fusion=False,
+    )
+    results = tuple(
+        (output, scale) if dtype is not None else output
+        for output, scale, dtype in zip(outputs, scales, output_dtypes)
+    )
+    return results[0] if len(results) == 1 else results
+
+
+def gemma_rmsnorm_quant_fp8(x, weight, residual=None, eps=1e-6,
+                          output_dtypes=(fp8_dtype,), input_scales=(None,)):
+    """Return normalized inputs per projection; update residual if given.
+
+    Static FP8 preserves BF16/FP16 intermediate rounding, which FlashInfer's
+    direct FP32-to-FP8 norm output does not provide.
+    """
+    return _launch_fp8_kernel(x, weight=weight, residual=residual, eps=eps, gemma=True,
+                             output_dtypes=output_dtypes, input_scales=input_scales)
+
+
+def rmsnorm_silu_gate_quant_fp8(x, weight, gate, eps=1e-6, input_scale=None):
+    """Return headwise RMSNorm(x) * SiLU(gate) as (FP8, scale)."""
+    return _launch_fp8_kernel(x, weight=weight, gate=gate, eps=eps, input_scales=(input_scale,))
+
+
+def silu_and_mul_quant_fp8(x, input_scale=None):
+    """Return SiLU(x[..., :d]) * x[..., d:] as (FP8, scale)."""
+    return _launch_fp8_kernel(x, silu_mul=True, input_scales=(input_scale,))
+
+
+def sigmoid_mul_quant_fp8(x, gate, input_scale=None):
+    """Return x * sigmoid(gate) as (FP8, scale)."""
+    return _launch_fp8_kernel(x, gate=gate, input_scales=(input_scale,))
 
 
 def sglang_per_token_quant_fp8(
@@ -1073,27 +938,6 @@ def prepare_block_fp8_matmul_inputs(
     return M, N, K, C
 
 
-def w8a8_block_fp8_matmul_deepgemm(
-    A: torch.Tensor,
-    B: torch.Tensor,
-    As: torch.Tensor,
-    Bs: torch.Tensor,
-    block_size: List[int],
-    output_dtype: torch.dtype,
-) -> torch.Tensor:
-    M, N, K, C = prepare_block_fp8_matmul_inputs(A, B, As, Bs, block_size, output_dtype)
-
-    # Deepgemm only supports output tensor type as bfloat16
-    assert C.dtype == torch.bfloat16 and deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-
-    if supports_custom_op():
-        torch.ops.sglang.deep_gemm_fp8_fp8_bf16_nt(A, As, B, Bs, C)
-    else:
-        deep_gemm_wrapper.gemm_nt_f8f8bf16((A, As), (B, Bs), C)
-
-    return C
-
-
 def w8a8_block_fp8_matmul_triton(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -1175,25 +1019,6 @@ def w8a8_block_fp8_matmul_triton(
     )
 
     return C
-
-
-# universal entry point, for testing purposes
-def w8a8_block_fp8_matmul(
-    A: torch.Tensor,
-    B: torch.Tensor,
-    As: torch.Tensor,
-    Bs: torch.Tensor,
-    block_size: List[int],
-    output_dtype: torch.dtype = torch.float16,
-) -> torch.Tensor:
-    if output_dtype == torch.bfloat16 and deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
-        return w8a8_block_fp8_matmul_deepgemm(
-            A, B, As, Bs, block_size, output_dtype=output_dtype
-        )
-
-    return w8a8_block_fp8_matmul_triton(
-        A, B, As, Bs, block_size, output_dtype=output_dtype
-    )
 
 
 @triton.jit
@@ -1678,6 +1503,7 @@ def scaled_mm_kernel(
     BLOCK_SIZE_K: tl.constexpr,
     BLOCK_SIZE_SCALE_A: tl.constexpr,
     BLOCK_SIZE_SCALE_B: tl.constexpr,
+    NATIVE_FP8_DOT: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
 
@@ -1728,10 +1554,15 @@ def scaled_mm_kernel(
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
         masks_k = offsets_k < K
         masks_a = masks_am[:, None] & masks_k[None, :]
-        a = tl.load(a_ptrs, mask=masks_a)
+        a = tl.load(a_ptrs, mask=masks_a, other=0.0)
 
         masks_b = masks_k[:, None] & masks_bn[None, :]
-        b = tl.load(b_ptrs, mask=masks_b)
+        b = tl.load(b_ptrs, mask=masks_b, other=0.0)
+
+        if not NATIVE_FP8_DOT:
+            # FP8 values are exact in BF16; convert inside GEMM on older GPUs.
+            a = a.to(tl.bfloat16)
+            b = b.to(tl.bfloat16)
 
         # Accumulate results.
         accumulator = tl.dot(a, b, accumulator, out_dtype=accumulator_dtype)
@@ -1829,7 +1660,7 @@ def triton_scaled_mm(
         else:
             tile_shape = (128, 128, 128)
 
-    block_size_m, block_size_n, block_size_k = tile_shape
+        block_size_m, block_size_n, block_size_k = tile_shape
 
     block_size_sa = 1 if has_scalar(scale_a) else block_size_m
     block_size_sb = 1 if has_scalar(scale_b) else block_size_n
@@ -1860,28 +1691,13 @@ def triton_scaled_mm(
         BLOCK_SIZE_K=block_size_k,
         BLOCK_SIZE_SCALE_A=block_size_sa,
         BLOCK_SIZE_SCALE_B=block_size_sb,
+        NATIVE_FP8_DOT=_native_fp8_dot or input.dtype != fp8_dtype,
     )
 
-    return result.to(out_dtype)
+    return result
 
 
 if _is_cuda:
-    if enable_sgl_per_token_group_quant_8bit:
-
-        @torch.library.register_fake("sgl_kernel::sgl_per_token_group_quant_8bit")
-        def _(
-            input, output_q, output_s, group_size, eps, fp8_min, fp8_max, scale_ue8m0
-        ):
-            return
-
-    else:
-        pass
-
-        # @torch.library.register_fake("sf_kernel::sgl_per_token_group_quant_fp8")
-        # def _(
-        #     input, output_q, output_s, group_size, eps, fp8_min, fp8_max, scale_ue8m0
-        # ):
-        #     return
 
     # FIXME: for some models, this fake registration will cause NaN outputs.
     # So we gate the fake registration with an environment variable for them.

--- a/python/sfllm/layers/quantization/fp8_utils.py
+++ b/python/sfllm/layers/quantization/fp8_utils.py
@@ -5,29 +5,19 @@ from sfllm.layers.quantization.fp8_kernel import (
     fp8_max,
     is_fp8_fnuz,
     per_token_group_quant_fp8,
-    scaled_fp8_quant,
     sglang_per_token_quant_fp8,
     static_quant_fp8,
-    triton_scaled_mm,
-    w8a8_block_fp8_matmul_deepgemm,
     w8a8_block_fp8_matmul_triton,
 )
-from sfllm.utils import get_bool_env_var
 from sfllm.utils.platform import current_platform
+
+try:
+    from sgl_kernel import fp8_scaled_mm
+except ImportError:
+    fp8_scaled_mm = None
 
 _is_fp8_fnuz = is_fp8_fnuz()
 _is_cuda = current_platform.is_cuda()
-_is_torch_scale_mm_available = current_platform.has_device_capability((8,9))
-# Input scaling factors are no longer optional in _scaled_mm starting
-# from pytorch 2.5. Allocating a dummy tensor to pass as input_scale
-TORCH_DEVICE_IDENTITY = None
-
-CUTLASS_BLOCK_FP8_SUPPORTED = False
-
-def cutlass_fp8_supported() -> bool:
-    """Check if CUTLASS FP8 is supported."""
-    return CUTLASS_BLOCK_FP8_SUPPORTED
-
 def triton_w8a8_block_fp8_linear(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -50,9 +40,6 @@ def triton_w8a8_block_fp8_linear(
         output += bias
     return output.to(dtype=input_2d.dtype).view(*output_shape)
 
-
-def dispatch_w8a8_block_fp8_linear() -> Callable:
-    return triton_w8a8_block_fp8_linear
 
 def input_to_float8(
     x: torch.Tensor, dtype: torch.dtype = fp8_dtype
@@ -95,180 +82,31 @@ def normalize_e4m3fn_to_e4m3fnuz(
         input_scale = input_scale * 2.0
     return weight, weight_scale, input_scale
 
-def requant_weight_ue8m0_inplace(weight, weight_scale_inv, weight_block_size):
-    assert isinstance(weight, torch.nn.Parameter)
-    assert isinstance(weight_scale_inv, torch.nn.Parameter)
-
-    new_weight, new_weight_scale_inv = requant_weight_ue8m0(
-        weight.to(weight_scale_inv.device), weight_scale_inv, weight_block_size
+def torch_scaled_mm(input, weight, input_scale, weight_scale, out_dtype, bias=None):
+    return torch._scaled_mm(
+        input, weight, scale_a=input_scale, scale_b=weight_scale,
+        out_dtype=out_dtype, bias=bias,
     )
 
-    offloader.update_param(weight, new_weight)
-    weight_scale_inv.data = new_weight_scale_inv
-
-
-def _process_scaled_mm_output(output, input_2d_shape, output_shape):
-    if type(output) is tuple and len(output) == 2:
-        output = output[0]
-    return torch.narrow(output, 0, 0, input_2d_shape[0]).view(*output_shape)
-
-def _apply_fallback_scaled_mm(
-    qinput,
-    weight,
-    x_scale,
-    weight_scale,
-    input_2d_shape,
-    output_shape,
-    bias,
-    input_dtype,
-):
-    if not _is_torch_scale_mm_available:
-        # Massage the input to be 2D
-        x = (qinput.to(input_dtype) * x_scale).to(input_dtype)
-        output = x@((weight.to(x.dtype)*weight_scale).to(x.dtype))
-        output = output if bias is None else output + bias
-
-        return output.view(*output_shape)
-
-    global TORCH_DEVICE_IDENTITY
-    if TORCH_DEVICE_IDENTITY is None:
-        TORCH_DEVICE_IDENTITY = torch.ones(1, dtype=torch.float32, device=weight.device)
-
-    output = torch._scaled_mm(
-        qinput,
-        weight,
-        scale_a=TORCH_DEVICE_IDENTITY,
-        scale_b=TORCH_DEVICE_IDENTITY,
-        out_dtype=torch.float32,
-    )
-
-    output = _process_scaled_mm_output(output, input_2d_shape, output_shape)
-    x_scale = torch.narrow(x_scale, 0, 0, input_2d_shape[0])
-
-    output = output * x_scale * weight_scale.t()
-    if bias is not None:
-        output = output + bias
-    return output.to(dtype=input_dtype)
 
 def apply_fp8_linear(
     input: torch.Tensor,
     weight: torch.Tensor,
     weight_scale: torch.Tensor,
     input_scale: Optional[torch.Tensor] = None,
-    input_scale_ub: Optional[torch.Tensor] = None,
     bias: Optional[torch.Tensor] = None,
-    cutlass_fp8_supported: bool = cutlass_fp8_supported(),
-    use_per_token_if_dynamic: bool = False,
-    pad_output: Optional[bool] = None,
-    compressed_tensor_quant: bool = False,
+    *,
+    scaled_mm: Callable,
 ) -> torch.Tensor:
-    # Note: we pad the input because torch._scaled_mm is more performant
-    # for matrices with batch dimension > 16.
-    # This could change in the future.
-    # We also don't pad when using torch.compile,
-    # as it breaks with dynamic shapes.
-    if pad_output is None:
-        pad_output = (
-            not get_bool_env_var("SGLANG_ENABLE_TORCH_COMPILE")
-            and not cutlass_fp8_supported
-        )
-    output_padding = 17 if pad_output else None
-
-    # View input as 2D matrix for fp8 methods
+    """Quantize a raw activation, then use the layer's selected scaled GEMM."""
     input_2d = input.view(-1, input.shape[-1])
-    output_shape = [*input.shape[:-1], weight.shape[1]]
-
-    if compressed_tensor_quant:
-        # Maybe apply padding to output, see comment in __init__
-        num_token_padding = output_padding
-        if cutlass_fp8_supported and weight_scale.numel() == weight.shape[1]:
-            num_token_padding = None
-        qinput, x_scale = scaled_fp8_quant(
-            input_2d,
-            input_scale,
-            num_token_padding=num_token_padding,
-            use_per_token_if_dynamic=use_per_token_if_dynamic,
-        )
+    if input_scale is not None:
+        qinput, x_scale = static_quant_fp8(input_2d, input_scale, repeat_scale=False)
+    elif _is_cuda and input_2d.shape[-1] % 4 == 0:
+        qinput, x_scale = sglang_per_token_quant_fp8(input_2d)
     else:
-        # cutlass w8a8 fp8 sgl-kernel only supports per-token scale
-        if input_scale is not None:
-            assert input_scale.numel() == 1
-            # broadcast per-tensor scale to per-token scale when supporting cutlass
-            qinput, x_scale = static_quant_fp8(
-                input_2d, input_scale, repeat_scale=cutlass_fp8_supported
-            )
-        else:
-            # default use per-token quantization if dynamic
-            if _is_cuda:
-                qinput, x_scale = sglang_per_token_quant_fp8(input_2d)
-            else:
-                # TODO(kkhuang): temporarily enforce per-tensor activation scaling if weight is per-tensor scaling
-                # final solution should be: 1. add support to per-tensor activation scaling.
-                # 2. solve the torch.compile error from weight_scale.numel() == 1 and x_scale.numel() > 1 (below line#308)
-                if _is_hip and weight_scale.numel() == 1:
-                    qinput, x_scale = scaled_fp8_quant(
-                        input_2d,
-                        input_scale,
-                        use_per_token_if_dynamic=use_per_token_if_dynamic,
-                    )
-                else:
-                    qinput, x_scale = per_token_group_quant_fp8(
-                        input_2d, group_size=input_2d.shape[1]
-                    )
-    # torch.scaled_mm supports per tensor weights + activations only
-    # so fallback to naive if per channel or per token
-    per_tensor_weights = weight_scale.numel() == 1
-    per_tensor_activations = x_scale.numel() == 1
-
-    if (
-        use_per_token_if_dynamic
-        and not per_tensor_weights
-        and not per_tensor_activations
-        # and (USE_ROWWISE_TORCH_SCALED_MM)
-    ):
-        # For now validated on ROCm platform
-        # fp8 rowwise scaling in torch._scaled_mm is introduced in
-        # https://github.com/pytorch/pytorch/pull/144432 using hipBLASLt
-        # and ROCm 6.3, which only exists in torch 2.7 and above.
-        # For CUDA platform please validate if the
-        # torch._scaled_mm support rowwise scaled GEMM
-        # Fused GEMM_DQ Rowwise GEMM
-        output = torch._scaled_mm(
-            qinput,
-            weight,
-            out_dtype=input.dtype,
-            scale_a=x_scale,
-            scale_b=weight_scale.t(),
-            bias=bias,
+        qinput, x_scale = per_token_group_quant_fp8(
+            input_2d, group_size=input_2d.shape[-1]
         )
-        return _process_scaled_mm_output(output, input_2d.shape, output_shape)
-
-    if per_tensor_weights and per_tensor_activations:
-        if not _is_torch_scale_mm_available:
-            # Massage the input to be 2D
-            x = (qinput.to(input.dtype) * x_scale).to(input.dtype)
-            output = x@((weight.to(x.dtype)*weight_scale).to(x.dtype))
-            output = output if bias is None else output + bias
-            return output.view(*output_shape)
-
-        # Fused GEMM_DQ
-        output = torch._scaled_mm(
-            qinput,
-            weight,
-            out_dtype=input.dtype,
-            scale_a=x_scale,
-            scale_b=weight_scale,
-            bias=bias,
-        )
-        return _process_scaled_mm_output(output, input_2d.shape, output_shape)
-    
-    return _apply_fallback_scaled_mm(
-        qinput,
-        weight,
-        x_scale,
-        weight_scale,
-        input_2d.shape,
-        output_shape,
-        bias,
-        input.dtype,
-    )
+    output = scaled_mm(qinput, weight, x_scale, weight_scale, input.dtype, bias)
+    return output.view(*input.shape[:-1], weight.shape[1])

--- a/python/sfllm/model_loader/model_loader.py
+++ b/python/sfllm/model_loader/model_loader.py
@@ -69,7 +69,7 @@ def get_quant_config(
     checkpoint_method = None
     if config is not None:
         checkpoint_method = config.get("quant_method")
-        if checkpoint_method == "modelopt" or "quantization" in config or "quant_algo" in config:
+        if checkpoint_method in ("modelopt", "compressed-tensors") or "quantization" in config or "quant_algo" in config:
             checkpoint_method = "fp8"
     method = model_config.quantization
     if method is not None and checkpoint_method is not None and method != checkpoint_method:

--- a/python/sfllm/models/qwen2.py
+++ b/python/sfllm/models/qwen2.py
@@ -66,7 +66,7 @@ class Qwen2MLP(nn.Module):
                 f"Unsupported activation: {hidden_act}. "
                 "Only silu is supported for now."
             )
-        self.act_fn = SiluAndMul()
+        self.act_fn = SiluAndMul(quant_method=self.down_proj.quant_method)
 
     def forward(self, x):
         gate_up, _ = self.gate_up_proj(x)

--- a/python/sfllm/models/qwen3_5.py
+++ b/python/sfllm/models/qwen3_5.py
@@ -16,6 +16,10 @@ import sf_kernel
 from sfllm.engine.forward_params import ForwardBatch, ForwardMode
 from sfllm.kernels.gdn import GatedDeltaNetBackend, gated_rmsnorm
 from sfllm.layers.layernorm import GemmaRMSNorm
+from sfllm.layers.quantization.fp8_kernel import (
+    rmsnorm_silu_gate_quant_fp8,
+    sigmoid_mul_quant_fp8,
+)
 from sfllm.layers.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
@@ -24,10 +28,11 @@ from sfllm.layers.linear import (
 )
 from sfllm.layers.logits_processor import LogitsProcessor
 from sfllm.layers.quantization import Fp8Config, QuantizationConfig
+from sfllm.layers.quantization.utils import is_layer_skipped
 from sfllm.layers.radix_attention import RadixAttention
 from sfllm.layers.rotary_embedding import get_rope
 from sfllm.model_loader.model_config import get_pool_index_layers
-from sfllm.model_loader.weight_utils import default_weight_loader
+from sfllm.model_loader.weight_utils import default_weight_loader, get_layer_id
 from sfllm.models.interfaces import HasBatchState
 from sfllm.models.qwen2 import Qwen2MLP
 from sfllm.server_args import get_global_server_args
@@ -57,13 +62,24 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         self.conv_states = conv_states
         self.ssm_states = ssm_states
         self.state_indices = state_indices
-        self.quant_config = quant_config
+        self.fused_in_proj = (
+            quant_config is None or quant_config.weight_strategy == "channel"
+        )
+        if quant_config is not None and self.fused_in_proj:
+            self.fused_in_proj = is_layer_skipped(
+                add_prefix("in_proj_qkvz", prefix), quant_config.ignored_layers,
+                quant_config.packed_modules_mapping,
+            ) == is_layer_skipped(
+                add_prefix("in_proj_ba", prefix), quant_config.ignored_layers,
+                quant_config.packed_modules_mapping,
+            )
 
         qkvz_sizes = [self.key_dim, self.key_dim, self.value_dim, self.value_dim]
         ba_sizes = [self.num_v_heads, self.num_v_heads]
-        if quant_config is None:
+        if self.fused_in_proj:
             self.in_proj_qkvzba = MergedColumnParallelLinear(
                 self.hidden_size, qkvz_sizes + ba_sizes, bias=False,
+                quant_config=quant_config,
                 prefix=add_prefix("in_proj_qkvzba", prefix),
             )
         else:
@@ -95,6 +111,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             quant_config=quant_config,
             prefix=add_prefix("out_proj", prefix),
         )
+        self.fp8_output = self.out_proj.quant_method.input_dtype is not None
         server_args = get_global_server_args()
         self.backend = GatedDeltaNetBackend(
             prefill_backend=(
@@ -114,21 +131,22 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         query_start_loc: Optional[torch.Tensor],
         query_start_loc_i64: Optional[torch.Tensor],
     ):
-        num_sequences = (
-            hidden_states.shape[0]
-            if forward_batch.forward_mode == ForwardMode.DECODE
-            else query_start_loc.shape[0] - 1
-        )
-        state_indices = self.state_indices[:num_sequences]
-
-        if self.quant_config is None:
+        mode = forward_batch.forward_mode
+        if self.fused_in_proj:
             projected, _ = self.in_proj_qkvzba(hidden_states)
             projected_qkvz, projected_ba = projected.split(
                 (self.conv_dim + self.value_dim, self.num_v_heads * 2), dim=-1
             )
         else:
-            projected_qkvz, _ = self.in_proj_qkvz(hidden_states)
-            projected_ba, _ = self.in_proj_ba(hidden_states)
+            qkvz_input, ba_input = hidden_states
+            projected_qkvz, _ = self.in_proj_qkvz(qkvz_input)
+            projected_ba, _ = self.in_proj_ba(ba_input)
+
+        num_tokens = projected_qkvz.shape[0]
+        num_sequences = num_tokens
+        if mode == ForwardMode.EXTEND:
+            num_sequences = query_start_loc.shape[0] - 1
+        state_indices = self.state_indices[:num_sequences]
 
         common = dict(
             conv_weight=self.conv_weight.view(self.conv_dim, self.conv_kernel_size),
@@ -163,9 +181,15 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 f"Qwen3.5 GDN does not support {forward_batch.forward_mode.name} yet"
             )
 
-        core = gated_rmsnorm(core, z, self.norm, self.rms_norm_eps).view(
-            hidden_states.shape[0], self.value_dim
-        )
+        if self.fp8_output:
+            core = rmsnorm_silu_gate_quant_fp8(
+                core, weight=self.norm, gate=z, eps=self.rms_norm_eps,
+                input_scale=self.out_proj.quant_method.input_scale,
+            )
+        else:
+            core = gated_rmsnorm(core, z, self.norm, self.rms_norm_eps).view(
+                num_tokens, self.value_dim
+            )
         output, _ = self.out_proj(core)
         return output
 
@@ -205,6 +229,7 @@ class Qwen3_5Attention(nn.Module):
             reduce_results=False,
             prefix=add_prefix("o_proj", prefix),
         )
+        self.fp8_output = self.o_proj.quant_method.input_dtype is not None
         self.q_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
 
@@ -277,7 +302,12 @@ class Qwen3_5Attention(nn.Module):
         )
         if gate is not None:
             output = output.view(-1, self.q_size)
-            sf_kernel.fused_sigmoid_mul(output, gate)
+            if self.fp8_output:
+                output = sigmoid_mul_quant_fp8(
+                    output, gate=gate, input_scale=self.o_proj.quant_method.input_scale,
+                )
+            else:
+                sf_kernel.fused_sigmoid_mul(output, gate)
         output, _ = self.o_proj(output)
         return output
 
@@ -303,6 +333,7 @@ class Qwen3_5DecoderLayer(nn.Module):
                 quant_config,
                 add_prefix("self_attn", prefix),
             )
+            input_projections = (self.self_attn.qkv_proj,)
         elif layer_type == "linear_attention":
             self.linear_attn = Qwen3_5GatedDeltaNet(
                 config,
@@ -311,6 +342,10 @@ class Qwen3_5DecoderLayer(nn.Module):
                 state_buffers[2],
                 quant_config,
                 add_prefix("linear_attn", prefix),
+            )
+            input_projections = (
+                (self.linear_attn.in_proj_qkvzba,) if self.linear_attn.fused_in_proj
+                else (self.linear_attn.in_proj_qkvz, self.linear_attn.in_proj_ba)
             )
         else:
             raise ValueError(f"Unsupported Qwen3.5 layer type: {layer_type}")
@@ -321,9 +356,13 @@ class Qwen3_5DecoderLayer(nn.Module):
             quant_config,
             add_prefix("mlp", prefix),
         )
-        self.input_layernorm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.input_layernorm = GemmaRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps,
+            quant_methods=tuple(p.quant_method for p in input_projections),
+        )
         self.post_attention_layernorm = GemmaRMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps
+            config.hidden_size, eps=config.rms_norm_eps,
+            quant_methods=(self.mlp.gate_up_proj.quant_method,),
         )
 
     def forward(
@@ -511,7 +550,7 @@ class Qwen3_5ForConditionalGeneration(nn.Module, HasBatchState):
         if quant_config is not None and (
             not isinstance(quant_config, Fp8Config) or quant_config.weight_block_size is not None
         ):
-            raise ValueError("Qwen3.5 only supports per-tensor FP8 quantization")
+            raise ValueError("Qwen3.5 only supports per-tensor or per-channel FP8 quantization")
         text_config = config.text_config
         self.config = text_config
         self.quant_config = quant_config
@@ -543,10 +582,6 @@ class Qwen3_5ForConditionalGeneration(nn.Module, HasBatchState):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params = dict(self.named_parameters())
         loaded = set()
-        qkvz_proj = "in_proj_qkvz" if self.quant_config is not None else "in_proj_qkvzba"
-        ba_proj = "in_proj_ba" if self.quant_config is not None else "in_proj_qkvzba"
-        ba_offset = 0 if self.quant_config is not None else 4
-
         for checkpoint_name, loaded_weight in weights:
             if checkpoint_name.startswith("model.visual.") or checkpoint_name.startswith("mtp."):
                 continue
@@ -557,6 +592,11 @@ class Qwen3_5ForConditionalGeneration(nn.Module, HasBatchState):
                 name = name.replace(".linear_attn.norm.weight", ".linear_attn.norm")
             if ".linear_attn.conv1d.weight" in name:
                 name = name.replace(".linear_attn.conv1d.weight", ".linear_attn.conv_weight")
+            if ".linear_attn.in_proj_" in name:
+                separate = not self.model.layers[get_layer_id(name)].linear_attn.fused_in_proj
+                qkvz_proj = "in_proj_qkvz" if separate else "in_proj_qkvzba"
+                ba_proj = "in_proj_ba" if separate else "in_proj_qkvzba"
+                ba_offset = 0 if separate else 4
 
             mappings = []
             if ".linear_attn.in_proj_qkv." in name:
@@ -567,7 +607,10 @@ class Qwen3_5ForConditionalGeneration(nn.Module, HasBatchState):
                         self.config.linear_num_value_heads * self.config.linear_value_head_dim,
                     ],
                     dim=0,
-                ) if name.endswith(".weight") else [loaded_weight] * 3
+                ) if name.endswith(".weight") or (
+                    name.endswith(".weight_scale")
+                    and self.quant_config.weight_strategy == "channel"
+                ) else [loaded_weight] * 3
                 target = name.replace("in_proj_qkv", qkvz_proj)
                 mappings = [(target, chunk, idx) for idx, chunk in enumerate(chunks)]
             elif ".linear_attn.in_proj_z." in name:


### PR DESCRIPTION
Support Qwen3.5 compressed-tensors `FP8_DYNAMIC` checkpoints with per-channel weight scales and per-token activation scales. Fuse FP8 output and its scales into RMSNorm/gated activations, with ModelOpt static FP8 and Triton fallback paths. Honor `max-context-length` for prefill so Polaris inputs above 8192 tokens are accepted.

Based on `main`; no dependency on the DFlash2/GDN changes. Measurements use `e454514`. All six cases are complete.

H100 NVL; BF16 activations outside FP8 linears; FA3, FlashInfer GDN prefill/decode, server CUDA Graph and overlap enabled. Server concurrency 32; client 24 for ShareGPT and GSM8K, 22 for Polaris.

| Model | Output tok/s | QPS | Avg output (range) | Accept len | GSM8K |
|---|---:|---:|---:|---:|---:|
| Qwen3-4B | 4460.50 | 4.6715 | 954.825 (78–1024) | — | 1148/1319 (87.04%) |
| Qwen3-4B + EAGLE3 | 5021.64 | 5.2797 | 951.128 (78–1024) | 2.5000 | 1150/1319 (87.19%) |
| Qwen3-4B + DFlash2 | 7101.26 | 7.4353 | 955.076 (78–1024) | 3.0950 | 1146/1319 (86.88%) |
| Qwen3.5-4B BF16 | 4347.53 | 4.4253 | 982.416 (145–1024) | — | 1146/1319 (86.88%) |
| Qwen3.5-4B ModelOpt FP8 | 5273.59 | 5.3727 | 981.545 (131–1024) | — | 1118/1319 (84.76%) |
| Qwen3.5 per-channel FP8 / Polaris | 2618.63 | 4.8478 | 540.170 (211–1000) | — | 1057/1319 (80.14%) |

All throughput runs completed successfully: 1000/0 requests per ShareGPT row and 500/0 for Polaris.

ShareGPT: 1000 prompts per row, seed 1, chat template, EOS respected, output cap 1024, one untimed warmup. Polaris: 500 prompts, seed 42, output cap 1000, stop token 248044, 22 untimed warmup requests capped at 32 tokens. Temperature 0 throughout. Accept len = successful output tokens / total decode rounds, excluding the prefill event. GSM8K: all 1319 test questions, 5-shot, greedy, max 512 tokens.

Concurrent GSM8K versus the earlier main measurements: Qwen3.5 BF16 1155 → 1146 and Qwen3 DFlash2 1149 → 1146. Replaying all 17 BF16 questions whose correctness changed in identical batches gives identical schedules and token IDs (6/17 correct on both). The DFlash2 control also matches all 3 token sequences and schedules (2/3 correct on both). These small controls do not replace the full concurrent scores above.

<details>
<summary>Server and client commands</summary>

From this branch, with the existing Python environment and compiled sfkernels:

```bash
source /workspace/sglang/.venv/bin/activate
export PYTHONPATH="$PWD/python:/workspace/sfllm/sfkernels/python"
# Choose the model and limits from the paths below.
MODEL=/mnt/data/jicwen/work/Qwen3-4B
MEM=0.7
CTX=8192
python python/sfllm/serving/app.py \
  --model-path "$MODEL" --port 8092 --dtype bfloat16 \
  --max-running-requests 32 --cuda-graph-max-bs 32 \
  --attention-backend fa3 --linear-attn-backend flashinfer \
  --mem-fraction "$MEM" --max-context-length "$CTX"
```

Model paths: `/mnt/data/jicwen/work/Qwen3-4B`, `/mnt/data/jicwen/work/Qwen3.5-4B`, `/mnt/data/jicwen/work/Qwen3.5-4B-ModelOpt-FP8`. Polaris uses `/mnt/data/work/dspark_repro_download/qwe35_dspark_qaa/dspark_repro/target`, `MEM=0.5`, `CTX=16384`. Qwen3.5 runs explicitly set both `--linear-attn-prefill-backend flashinfer` and `--linear-attn-decode-backend flashinfer`.

Append for Qwen3 EAGLE3:

```bash
--speculative-algorithm eagle3 \
--speculative-draft-model-path /mnt/data/jicwen/work/Qwen3-4B_eagle3 \
--speculative-num-steps 4 --speculative-eagle-topk 4 --speculative-num-draft-tokens 8
```

Append for Qwen3 DFlash2 (checkpoint block size 8):

```bash
--speculative-algorithm dflash2 \
--speculative-draft-model-path /mnt/data/jicwen/work/Qwen3-4B-speculator.dflash2
```

Wait for `Application startup complete` and `curl --fail http://127.0.0.1:8092/health` before running a client.

ShareGPT client used for measurements; the wrapper records output IDs and stream events for aggregate accept length:

```bash
RAW_IDS_PATH=/tmp/sharegpt-raw-ids.jsonl \
python /tmp/sfllm-review20-20260908/client/bench_with_ids.py \
  --backend sglang-native --host 127.0.0.1 --port 8092 \
  --model "$MODEL" --tokenizer "$MODEL" \
  --dataset-name sharegpt \
  --dataset-path /mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json \
  --num-prompts 1000 --max-concurrency 24 \
  --sharegpt-context-len 8192 --sharegpt-output-len 1024 \
  --seed 1 --warmup-requests 1 --disable-ignore-eos --apply-chat-template \
  --output-details --output-file /tmp/sharegpt-results.jsonl
```

Polaris client (first prewarm using `--num-prompts 22 --max-new-tokens 32` and a separate output directory):

```bash
export DSPARK_ROOT=/mnt/data/work/dspark_repro_download/qwe35_dspark_qaa/dspark_repro
python "$DSPARK_ROOT/benchmark/bench_sglang_raw.py" \
  --url http://127.0.0.1:8092/generate \
  --input "$DSPARK_ROOT/data/dashv4_polaris_test_data.jsonl" \
  --output-dir /tmp/polaris-results --concurrency 22 \
  --max-new-tokens 1000 --num-prompts 0 --temperature 0 --seed 42 --stop-token-id 248044
```

GSM8K client, against the same server:

```bash
python /tmp/sfllm-pr1-serving-fix.2dldw1tz/gsm8k_client.py \
  --port 8092 --max-concurrency 24 --num-shots 5 --max-new-tokens 512 \
  --output-dir /tmp/gsm8k-results
```

`sglang-native` identifies the HTTP protocol; all servers here are SFLLM. Exact per-run commands, source hashes and raw results are stored in `/mnt/data/jicwen/work/sfllm-pr-split-20260909-pjooq8ky/pr1-measurements/candidate`. Validation tools and dataset hashes are saved alongside them.

</details>
