### PR TITLE
fix: honor EAGLE3 RoPE config with Transformers 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ python python/sfllm/serving/app.py \
   --dtype float16
 ```
 
+**AngelSlim EAGLE3 config note:** Our tests favor `rope_theta=10000` in the
+draft `config.json` for `AngelSlim/Qwen3-4B_eagle3` and
+`AngelSlim/Qwen3-1.7B_eagle3`. Their configs declare `1000000`, but
+[AngelSlim's published training code](https://github.com/Tencent/AngelSlim/blob/917de3ae8c3147ff158b1b7a9c40082808486ae9/angelslim/compressor/speculative/train/models/draft/llama_eagle3.py#L186-L190)
+uses RoPE's default base of `10000`. Keep the target at `1000000`;
+this correction is specific to these draft checkpoints.
+
+ShareGPT acceptance length (`1000000` → `10000`): **4B: 2.3871 → 2.4971**
+(1000 requests); **1.7B: 2.3170 → 2.4012** (32 requests). Both used BF16,
+FA3, EAGLE3 4/4/8, server concurrency 32, client concurrency 22, and EOS enabled;
+acceptance length excludes the prefill token. The tested 1.7B draft also needs
+`tie_word_embeddings=false`: its 32000-row output head cannot share the
+151936-row target embedding.
+
 **Qwen3.5 FP8:**
 
 Export a calibrated Hugging Face checkpoint with NVIDIA ModelOpt's

--- a/python/sfllm/model_loader/registry.py
+++ b/python/sfllm/model_loader/registry.py
@@ -121,4 +121,3 @@ def import_model_classes(package_name: str):
 
 ModelRegistry = _ModelRegistry()
 ModelRegistry.register("sfllm.models")
-ModelRegistry.models["Eagle3LlamaForCausalLM"] = ModelRegistry.models["LlamaForCausalLMEagle3"]

--- a/python/sfllm/models/llama.py
+++ b/python/sfllm/models/llama.py
@@ -193,8 +193,15 @@ class LlamaDecoderLayer(nn.Module):
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
-        rope_theta = getattr(config, "rope_theta", 10000)
-        rope_scaling = getattr(config, "rope_scaling", None)
+        # Transformers 5 may move rope_theta into rope_parameters/rope_scaling.
+        # Honor the configured value; correct affected AngelSlim draft configs
+        # in config.json, as described in README.md, rather than overriding here.
+        rope_scaling = getattr(config, "rope_parameters", None)
+        if rope_scaling is None:
+            rope_scaling = getattr(config, "rope_scaling", None)
+        rope_theta = (rope_scaling or {}).get(
+            "rope_theta", getattr(config, "rope_theta", 10000)
+        )
         if rope_scaling is not None and getattr(
             config, "original_max_position_embeddings", None
         ):

--- a/python/sfllm/models/llama_eagle3.py
+++ b/python/sfllm/models/llama_eagle3.py
@@ -29,7 +29,7 @@ from sfllm.engine.forward_params import  ForwardBatch
 from sfllm.layers.layernorm import RMSNorm
 from sfllm.layers.linear import QKVParallelLinear
 from sfllm.layers.quantization import QuantizationConfig
-from sfllm.utils import add_prefix, get_tensor_model_parallel_world_size,make_layers_non_pp
+from sfllm.utils import add_prefix
 
 
 class LlamaDecoderLayer(LlamaDecoderLayer):
@@ -260,5 +260,7 @@ class LlamaForCausalLMEagle3(LlamaForCausalLM):
     def get_hot_token_id(self):
         return self.hot_token_id
 
+class Eagle3LlamaForCausalLM(LlamaForCausalLMEagle3):
+    ...
 
-EntryClass = [LlamaForCausalLMEagle3]
+EntryClass = [LlamaForCausalLMEagle3, Eagle3LlamaForCausalLM]


### PR DESCRIPTION
Transformers 5 can move `rope_theta` into `rope_parameters`/`rope_scaling`. Read that value before falling back to legacy fields, so EAGLE3 respects the configured RoPE base. Register both EAGLE3 architecture names through `EntryClass`, remove unused imports, and document the tested AngelSlim draft configuration corrections.

Validation uses BF16, FA3, EAGLE3 **4/4/8**, server concurrency **32**, client concurrency **22**, temperature 0, EOS enabled, CUDA Graph and overlap enabled. Warmup is excluded with `/flush_cache`. Acclen is `(output tokens - prefill first tokens) / decode rounds`, cross-checked against `/get_server_info` and captured token IDs.

| Target + AngelSlim EAGLE3 | Dataset | Requests | Acclen: theta 1000000 | Acclen: theta 10000 |
|---|---|---:|---:|---:|
| Qwen3-4B | ShareGPT | 1000 | 2.3871 | 2.4971 |
| Qwen3-4B | GSM8K | 1319 | 2.3729 | 2.5646 |
| Qwen3-1.7B | ShareGPT | 32 | 2.3170 | 2.4012 |

All requests succeeded. GSM8K accuracy: **1152/1319 (87.34%)** at 1000000 and **1148/1319 (87.04%)** at 10000. These runs compare effective draft RoPE values; the target remains at 1000000. The 4B control restored legacy field reads to obtain 10000; the 1.7B comparison changed only the temporary draft RoPE config. Outputs are not bitexact across RoPE settings.

Both 1.7B variants also use `tie_word_embeddings=false` to load the checkpoint's separate 32000-row output head. Its `.bin` weights were converted to safetensors with all 15 tensors verified bitexact and dtypes preserved. These checkpoint adjustments are documented; no model files are committed.

<details>
<summary>Server and client settings</summary>

Server command (set the draft config to the RoPE value being tested):

```bash
export PYTHONPATH="$PWD/python:$PWD/sfkernels/python"
export BENCH_MODEL=/mnt/data/jicwen/work/Qwen3-4B
export BENCH_DRAFT=/mnt/data/jicwen/work/Qwen3-4B_eagle3
export BENCH_DATASET=/mnt/data/jicwen/work/ShareGPT_V3_unfiltered_cleaned_split.json

python python/sfllm/serving/app.py \
  --model-path "$BENCH_MODEL" --speculative-draft-model-path "$BENCH_DRAFT" \
  --speculative-algorithm eagle3 --speculative-num-steps 4 \
  --speculative-eagle-topk 4 --speculative-num-draft-tokens 8 \
  --dtype bfloat16 --attention-backend fa3 \
  --max-running-requests 32 --cuda-graph-max-bs 32 \
  --max-context-length 8192 --mem-fraction 0.7 --port 31001
```

After `Application startup complete`, the repository client reproduces the ShareGPT request settings below. Recorded runs used a streaming `/generate` capture client with the same sampler to additionally compare output token IDs and decode-round counts.

```bash
curl --fail http://127.0.0.1:31001/health
python benchmark/bench_serving.py \
  --backend sglang-native --host 127.0.0.1 --port 31001 \
  --model "$BENCH_MODEL" --tokenizer "$BENCH_MODEL" \
  --dataset-name sharegpt --dataset-path "$BENCH_DATASET" \
  --num-prompts 1000 --max-concurrency 22 \
  --sharegpt-context-len 8192 --sharegpt-output-len 1024 \
  --seed 1 --warmup-requests 1 --disable-ignore-eos --apply-chat-template \
  --output-details --output-file /tmp/eagle3-sharegpt.jsonl
```

For 1.7B, use the corresponding target/draft paths and `--num-prompts 32`. GSM8K uses the full test split, 5 shots from train, max output 512, and stops `Question:`, `Assistant:`, `<|separator|>`.

Captured results and exact launch records:

- `/tmp/sfllm-qwen4b-rope-1000-c22-uqfbfg42/comparison.json`
- `/tmp/sfllm-qwen17-rope-ww4_87n1/comparison.json`

</details>

Checks: Python syntax for all changed modules and `git diff --check` passed.
