### PR TITLE
fix: restore interval speculative acceptance metrics

### DIFF
--- a/python/sfllm/engine/scheduler_metrics.py
+++ b/python/sfllm/engine/scheduler_metrics.py
@@ -26,6 +26,8 @@ class RunningMetrics:
 
     def reset(self):
         self.num_generated_tokens = 0
+        self.spec_num_forward_ct = 0
+        self.spec_num_accepted_tokens = 0
         self.cum_forward_ct = 0
         self.cum_spec_accept_tokens = 0
         self.prefill_tokens = 0
@@ -44,6 +46,10 @@ class RunningMetrics:
         num_accepted_tokens = spec_info.accept_length_cpu.sum().item()
         if num_accepted_tokens < 0:
             return
+        # Live logs average this interval; completed-output totals stay separate.
+        batch_size = len(spec_info.accept_length_cpu)
+        self.spec_num_forward_ct += batch_size
+        self.spec_num_accepted_tokens += num_accepted_tokens + batch_size
         self.num_generated_tokens += num_accepted_tokens
 
     def log_prefill_metrics(self, schedule_batch: ScheduleBatch):
@@ -91,11 +97,12 @@ class RunningMetrics:
                 f"gen throughput (token/s): {self.num_generated_tokens / elapsed:.2f}, "
                 f"cache usage: {cache_usage:.2f}%"
             )
-            if schedule_batch.spec_info is not None and self.cum_forward_ct:
-                avg_accept_lengths = self.cum_spec_accept_tokens / self.cum_forward_ct
+            if schedule_batch.spec_info is not None and self.spec_num_forward_ct:
+                avg_accept_lengths = self.spec_num_accepted_tokens / self.spec_num_forward_ct
                 msg += f", accept len: {avg_accept_lengths:.2f}"
             logger.info(msg)
             self.last_refresh_time = current_time
             self.num_generated_tokens = 0
+            self.spec_num_accepted_tokens = self.spec_num_forward_ct = 0
 
         self.num_generated_tokens += batch_size


### PR DESCRIPTION
Live speculative acceptance logs can stay at zero until requests finish because #31 uses completed-request token totals for the live numerator while decode verification counts already increase.

Restore separate interval counters for live `accept len`: sum accepted draft tokens plus one target token per request verification, divided by the number of request verifications. Reset these counters after each decode log. The cumulative completed-request accounting and server-info metrics from #31 remain unchanged, as do the existing log cadence and prefill logging.

Validation with Qwen3.5 + DFlash2:
- Offline generation: replaying the same model results through the original and fixed metrics preserved cumulative totals at every step (4,092 tokens / 1,182 request verifications). Before any requests completed, the live value correctly reported 1.25 instead of 0.
- Polaris500, concurrency 20: 500/500 requests succeeded; 36 live intervals reported acceptance lengths of 2.97–3.40. Client output counts and stream-event counts independently matched server cumulative totals: 271,001 / 83,803 = 3.233786379963.

These model runs used the development checkout; the metrics file is byte-identical to this PR. The isolated commit changes only `scheduler_metrics.py`; its syntax and diff checks pass, and cumulative counter updates match the base revision.
