### PR TITLE
perf: pack draft KV indices from contiguous storage

### DIFF
--- a/python/sfllm/engine/schedule_batch.py
+++ b/python/sfllm/engine/schedule_batch.py
@@ -14,6 +14,16 @@ from sfllm.server_args import get_global_server_args
 from sfllm.spec_decoding.spec_common import SpecInput
 
 
+def _pack_cache_indices(parts, padding, device):
+    """Copy local CPU views into batch-owned pinned storage before H2D."""
+    count = sum(part.numel() for part in parts)
+    staging = torch.empty(count + padding, dtype=torch.int64, device="cpu", pin_memory=True)
+    torch.cat(parts, out=staging[:count])
+    if padding:
+        staging[count:].zero_()
+    return staging.to(device, non_blocking=True)
+
+
 class ScheduleBatch:
     def __init__(self, sequences, mem_pool, draft_mem_pool=None):
         self.sequences:RequestSequence = sequences
@@ -91,20 +101,17 @@ class ScheduleBatch:
         return group_hash
 
     def prepare_prefill_for_draft(self):
-        spec_out_cache_loc_list = []
-        spec_kv_indices_list = []
+        spec_out_cache_parts = []
+        spec_kv_indices_parts = []
         device = self.device
         for sequence in self.sequences:
-            spec_out_cache_loc_list.extend(sequence.out_cache_loc_spec[-len(sequence.new_tokens):])
-            spec_kv_indices_list.extend(sequence.out_cache_loc_spec)
+            cache_locs = torch.from_numpy(np.asarray(sequence.out_cache_loc_spec, dtype=np.int64))
+            spec_out_cache_parts.append(cache_locs[-len(sequence.new_tokens):])
+            spec_kv_indices_parts.append(cache_locs)
 
         padded_token = self.forward_batch.padded_token
-        if padded_token > 0:
-            spec_out_cache_loc_list.extend([0] * padded_token)
-            spec_kv_indices_list.extend([0] * padded_token)
-
-        out_cache_loc_spec = torch.tensor(spec_out_cache_loc_list, dtype=torch.int64, pin_memory=True).to(device, non_blocking=True)
-        kv_indices_spec = torch.tensor(spec_kv_indices_list, dtype=torch.int64, pin_memory=True).to(device, non_blocking=True)
+        out_cache_loc_spec = _pack_cache_indices(spec_out_cache_parts, padded_token, device)
+        kv_indices_spec = _pack_cache_indices(spec_kv_indices_parts, padded_token, device)
 
         self.forward_batch_spec.max_extend_len = self.forward_batch.max_extend_len
         self.forward_batch_spec.kv_indptr = self.forward_batch.kv_indptr
@@ -164,7 +171,7 @@ class ScheduleBatch:
         position_ids_list = list(itertools.chain.from_iterable(positions_outs))
 
         spec_out_cache_loc_list = []
-        spec_kv_indices_list = []
+        spec_kv_indices_parts = []
         spec_kv_indptr_list = [0]
         device = self.device
         for sequence in self.sequences:
@@ -175,14 +182,15 @@ class ScheduleBatch:
             else:
                 spec_out_cache_loc_list.extend(sequence.out_cache_loc_spec[-total_draft_len:])
             spec_kv_indptr_list.append(spec_kv_indptr_list[-1] + len(sequence.out_cache_loc_spec))
-            spec_kv_indices_list.extend(sequence.out_cache_loc_spec)
+            spec_kv_indices_parts.append(torch.from_numpy(
+                np.asarray(sequence.out_cache_loc_spec, dtype=np.int64)
+            ))
 
         padded_token = self.forward_batch.padded_token
         if padded_token > 0:
             spec_out_cache_loc_list.extend([0] * padded_token)
-            spec_kv_indices_list.extend([0] * padded_token)
         out_cache_loc_spec = torch.tensor(spec_out_cache_loc_list, dtype=torch.int64, pin_memory=True).to(device, non_blocking=True)
-        kv_indices_spec = torch.tensor(spec_kv_indices_list, dtype=torch.int64, pin_memory=True).to(device, non_blocking=True)
+        kv_indices_spec = _pack_cache_indices(spec_kv_indices_parts, padded_token, device)
 
         #kv_indptr would be used in two place, extend forward for the latest accepted token,, the other is multi-step draft decode path
         self.forward_batch_spec.kv_indptr = torch.tensor(
@@ -284,17 +292,7 @@ class ScheduleBatch:
         position_ids = torch.tensor(position_ids_list, dtype=torch.long, pin_memory=True).to(device, non_blocking=True)
         cur_seq_lens = torch.tensor(cur_seq_lens_list, dtype=torch.int32, pin_memory=True).to(device, non_blocking=True)
         out_cache_loc = torch.tensor(out_cache_loc_list, dtype=torch.int64, pin_memory=True).to(device, non_blocking=True)
-        num_kv_indices = sum(part.shape[0] for part in kv_indices_parts)
-        kv_indices_cpu = torch.empty(
-            num_kv_indices + padded_token,
-            dtype=torch.int64,
-            device="cpu",
-            pin_memory=True,
-        )
-        torch.cat(kv_indices_parts, out=kv_indices_cpu[:num_kv_indices])
-        if padded_token:
-            kv_indices_cpu[num_kv_indices:].zero_()
-        kv_indices = kv_indices_cpu.to(device, non_blocking=True)
+        kv_indices = _pack_cache_indices(kv_indices_parts, padded_token, device)
 
         prefix_lens = torch.tensor(prefix_lens_list, dtype=torch.int32, pin_memory=True).to(device, non_blocking=True)
 

--- a/python/sfllm/engine/scheduler.py
+++ b/python/sfllm/engine/scheduler.py
@@ -78,7 +78,7 @@ class Scheduler:
     def swap_req_to_waiting(self, sequence: RequestSequence):
         self.free_sequence_resources(sequence)
         del sequence.out_cache_loc[:]
-        sequence.out_cache_loc_spec = []
+        del sequence.out_cache_loc_spec[:]
         sequence.status = "WAITING"
         sequence.new_tokens = sequence.tokens.copy()
         self.waiting_queue.put(sequence)

--- a/python/sfllm/engine/sequence.py
+++ b/python/sfllm/engine/sequence.py
@@ -88,7 +88,7 @@ class RequestSequence(RawSequence):
             sampling_params = SamplingParams()
         super().__init__(prompt=prompt, sampling_params=sampling_params)
         self.out_cache_loc = array("q")
-        self.out_cache_loc_spec = []
+        self.out_cache_loc_spec = array("q")
         self.out_cache_loc_lazy = None  # (CUDA source tensor, CUDA [start, end) row range)
         self.request_index = -1
         self.stream = stream


### PR DESCRIPTION
Draft batch preparation flattens each request's historical KV indices into a Python list and converts every integer through `torch.tensor` on each step. Store draft indices in `array("q")` and reuse the target's existing pinned-buffer packing to copy contiguous integer data in bulk.

The change covers the complete storage lifecycle in three files:
- `sequence.py` initializes draft indices as a signed 64-bit array.
- `schedule_batch.py` creates local views and packs target/draft indices through the same helper.
- `scheduler.py` clears the array when a request returns to the waiting queue, preserving its type.

Index order, slice boundaries, values, and zero padding remain the same. CPU concatenation creates an independent pinned snapshot before asynchronous H2D; request mutations occur after preparation returns. The PyTorch allocator tracks unfinished copies, and the existing compute-stream waits and storage lifetime handling remain in place. All draft-index mutation and release sites were reviewed for compatibility with array slicing, extension, iteration, and clearing.

Validation: Python syntax and `git diff --check` pass. Prior direct old/new metadata and pending-H2D comparisons matched across 72 cases; these checks supplement the code review and do not establish exhaustive coverage. No new repository tests are included.

A focused measurement on this host (Python 3.12.3, PyTorch 2.13.0+cu130, inference mode, 20 requests with 4,096 historical indices each) reduced complete `prepare_inputs` CPU submission time from about 5.36 ms to 0.49 ms. The original Python-list-to-pinned-tensor conversion alone took about 4.55 ms. This measures metadata preparation rather than serving throughput; very short inputs can be slower (single-request, 16-index packing: about 12 vs. 18 microseconds).
