### PR TITLE
fix: use native sliding windows for DFlash2

### DIFF
--- a/python/sfllm/kernels/fa3_attention.py
+++ b/python/sfllm/kernels/fa3_attention.py
@@ -15,13 +15,10 @@ def _build_page_table_kernel(
     page_table_stride: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     APPEND_QUERY: tl.constexpr,
-    PREFIX_WINDOW: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
     prefix_start = tl.load(kv_indptr + batch_idx).to(tl.int64)
     prefix_end = tl.load(kv_indptr + batch_idx + 1).to(tl.int64)
-    if PREFIX_WINDOW > 0:
-        prefix_start = tl.maximum(prefix_start, prefix_end - PREFIX_WINDOW)
     prefix_len = prefix_end - prefix_start
     if APPEND_QUERY:
         query_start = tl.load(qo_indptr + batch_idx).to(tl.int64)
@@ -68,7 +65,6 @@ def build_page_table(
     cache_seqlens: torch.Tensor,
     *,
     append_query: bool,
-    prefix_window: int = -1,
 ) -> None:
     _build_page_table_kernel[(page_table.shape[0],)](
         kv_indices,
@@ -80,7 +76,6 @@ def build_page_table(
         page_table.stride(0),
         BLOCK_SIZE=256,
         APPEND_QUERY=append_query,
-        PREFIX_WINDOW=prefix_window,
         num_warps=4,
     )
 
@@ -95,6 +90,7 @@ def fa3_attention_fwd(
     causal: bool,
     *,
     return_softmax_lse: bool = False,
+    sliding_window_size: tuple[int, int] = (-1, -1),
 ) -> torch.Tensor:
     result = flash_attn_with_kvcache(
         q,
@@ -106,6 +102,7 @@ def fa3_attention_fwd(
         max_seqlen_q=metadata.max_query_len,
         softmax_scale=softmax_scale,
         causal=causal,
+        window_size=sliding_window_size,
         num_splits=0,
         scheduler_metadata=metadata.scheduler_metadata,
         return_softmax_lse=return_softmax_lse,

--- a/python/sfllm/layers/fa3_attention.py
+++ b/python/sfllm/layers/fa3_attention.py
@@ -74,10 +74,6 @@ class FA3AttentionWorkspace:
             page_table,
             cache_seqlens,
             append_query=not is_decode and not is_tree_verify,
-            prefix_window=(
-                layer.sliding_window_size
-                if forward_batch.forward_mode == ForwardMode.DRAFT_EXTEND else -1
-            ),
         )
         scheduler_metadata = get_scheduler_metadata(
             batch_size=batch_size,
@@ -91,6 +87,7 @@ class FA3AttentionWorkspace:
             cu_seqlens_q=qo_indptr,
             page_size=1,
             causal=layer.is_causal and not is_tree_verify,
+            window_size=layer.sliding_window_size,
             num_splits=0,
         )
         return FA3AttentionMetadata(
@@ -170,4 +167,5 @@ class FA3AttentionBackend:
             metadata,
             layer.scaling,
             layer.is_causal,
+            sliding_window_size=layer.sliding_window_size,
         )

--- a/python/sfllm/layers/radix_attention.py
+++ b/python/sfllm/layers/radix_attention.py
@@ -66,7 +66,7 @@ class RadixAttention(nn.Module):
         layer_id: int,
         logit_cap: float = 0.0,
         v_head_dim: int = -1,
-        sliding_window_size: int = -1,
+        sliding_window_size: tuple[int, int] = (-1, -1),
         is_cross_attention: bool = False,
         pos_encoding_mode: str = "NONE",
         logit_capping_method: str = "tanh",
@@ -83,7 +83,7 @@ class RadixAttention(nn.Module):
         self.scaling = scaling
         self.layer_id = layer_id
         self.logit_cap = logit_cap
-        self.sliding_window_size = sliding_window_size or -1
+        self.sliding_window_size = sliding_window_size
         self.is_cross_attention = is_cross_attention
         self.is_causal = True
         self.use_irope = use_irope

--- a/python/sfllm/layers/verify_attention.py
+++ b/python/sfllm/layers/verify_attention.py
@@ -71,7 +71,7 @@ def verify_attention(q, k, v, layer, forward_batch, save_kv_cache=True, *, works
         or layer.qk_head_dim != layer.v_head_dim
         or layer.qk_head_dim > 256
         or layer.qk_head_dim % 8
-        or layer.sliding_window_size > 0
+        or layer.sliding_window_size != (-1, -1)
         or layer.logit_cap
         or layer.is_cross_attention
     ):

--- a/python/sfllm/models/dflash2.py
+++ b/python/sfllm/models/dflash2.py
@@ -129,11 +129,12 @@ class DFlash2Attention(Qwen3Attention):
         )
         self.attn.is_causal = False
         if config.layer_types[layer_id] == "sliding_attention":
-            self.attn.sliding_window_size = int(config.sliding_window)
             self.attn.is_causal = getattr(
                 config, "is_causal",
                 not config.dflash_config.get("sliding_window_non_causal", False),
             )
+            window = int(config.sliding_window) - 1
+            self.attn.sliding_window_size = (window, 0 if self.attn.is_causal else window)
 
     def materialize_kv(
         self,


### PR DESCRIPTION
DFlash2's FA3 path clips the historical KV prefix at a fixed boundary for the entire draft block. Use FA3's native per-query sliding window: `(W - 1, 0)` for causal layers and `(W - 1, W - 1)` for noncausal layers.

Pass the same window to scheduler preparation and attention execution, remove `prefix_window` / `PREFIX_WINDOW` and the prefix clipping, and update the shared window type and tree-verification full-window check. This is 5 files, +9/-13; the DFlash2 model change itself is +2/-1. It excludes the `forward_model` wrapper, preparation refactor, worker changes, and DSpark integration.

Validation on commit `3d14a26`:

- `git diff --check` passed. All verification scripts and artifacts are outside the repository.
- 35 temporary GPU checks passed: FP16/BF16 full attention and sliding windows W=1/4/4096 against independent FP32 attention math, full attention and EAGLE tree verification byte-for-byte against main, and CUDA graph replays with changing queries, KV values, and page indices byte-for-byte against eager execution. The old block-anchored sliding mask has different semantics; whole-model bitexactness against that mask is not claimed.
- Polaris500 completed from this PR worktree with Qwen3.5 + DFlash2 on H100 NVL: FP8 target checkpoint, BF16 draft/activations, **FP32 SSM, concurrency 22, block 5**, FA3/FlashInfer, greedy, max output 1000, seed 42. The earlier main worktree run (`06417df`) used identical server/warmup/benchmark arguments apart from paths and labels, with identical hashes for all 500 prompts. Each run warmed up 22 requests and reset caches and counters before measurement.

| Worktree | QPS | p95 E2E (s) | Avg output tokens | Accept len | Mean TPOT (ms) | p95 TTFT (ms) | Output tok/s | Success/fail | Wall (s) |
|---|---:|---:|---:|---:|---:|---:|---:|---|---:|
| main | 6.3619 | 4.7766 | 537.35 | 3.03727 | 6.083 | 294.184 | 3418.58 | 500/0 | 78.59 |
| PR | 6.4105 | 4.8191 | 538.83 | 3.03764 | 6.028 | 250.199 | 3454.13 | 500/0 | 78.00 |

Single-run differences: QPS +0.76%, output throughput +1.04%, accept length +0.000365. These runs do not establish a stable performance improvement.

PR acceptance counters independently match client records: `sum(completion_tokens - 1) / sum(stream_event_count - 1) = 268913 / 88527 = 3.037638234663`. Source hashes remained unchanged throughout the run. The original working tree and staged changes are preserved.
