### PR TITLE
fix: correct EAGLE3 KV prefix and branch buffer capacity

### DIFF
--- a/python/sfllm/engine/inference_engine.py
+++ b/python/sfllm/engine/inference_engine.py
@@ -330,7 +330,8 @@ class InferenceEngine:
                         b = cur_batch.forward_batch_spec.kv_indptr
                         # x1=x.clone()
                         cur_batch.forward_batch_spec.kv_indices_mtd = compact_accepted_tokens(x, b, cur_batch.forward_batch.seq_lens)
-                        cur_batch.forward_batch_spec.kv_indices = cur_batch.forward_batch_spec.kv_indices_mtd
+                        prefix_lens = cur_batch.forward_batch.seq_lens - accept_length
+                        cur_batch.forward_batch_spec.kv_indices = compact_accepted_tokens(x, b, prefix_lens, fill_value=0)
 
                         # row_ids = torch.arange(x.shape[0], device=device_id)
                         # seg_ids = torch.searchsorted(b, row_ids, right=True) - 1  # [N]
@@ -341,7 +342,7 @@ class InferenceEngine:
                         # x[mask] = -1
                         # x[:] = move_neg1_to_tail(x)
                         # cur_batch.forward_batch_spec.kv_indices_mtd -= extra_length # can't handle it here, may generate_kv_indices_kernel
-                        cur_batch.forward_batch_spec.kv_indptr[1:] = cur_batch.forward_batch.seq_lens.cumsum(dim=0)
+                        cur_batch.forward_batch_spec.kv_indptr[1:] = prefix_lens.cumsum(dim=0)
                         if cur_batch.spec_info.out_cache_loc is not None:
                             # even we don't know the accept index yet, we can adjust it in GPU async
                             # would it affect when this is in the scheduler stream?
@@ -368,7 +369,7 @@ class InferenceEngine:
                             # cur_batch.forward_batch.kv_indices[:draft_token_steps-len(cur_batch)] = resolve_out_cache_loc
                             # cur_batch.forward_batch.kv_indices[:] = move_neg1_to_tail(cur_batch.forward_batch.kv_indices)
                             # cur_batch.forward_batch.kv_indices = cur_batch.forward_batch.kv_indices[:len(cur_batch)*num_draft_tokens]
-                        cur_batch.forward_batch.kv_indptr[1:] = cur_batch.forward_batch_spec.kv_indptr[1:]
+                        cur_batch.forward_batch.kv_indptr[1:] = cur_batch.forward_batch.seq_lens.cumsum(dim=0)
 
                         x = cur_batch.forward_batch_spec.position_ids_extend
                         x.record_stream(compute_stream)

--- a/python/sfllm/engine/schedule_batch.py
+++ b/python/sfllm/engine/schedule_batch.py
@@ -136,10 +136,9 @@ class ScheduleBatch:
                 src_hd_list = [ seq.hidden_states[0] for seq in self.sequences]
                 src_range_list = [ seq.hidden_states[1] for seq in self.sequences]
                 src_range = torch.stack(src_range_list, dim=0)
-                draft_steps = hidden_states_buffer.shape[1]
                 hidden_states_buffer = hidden_states_buffer.view(-1, hidden_states_buffer.shape[-1])
                 self.spec_info.hidden_states = copy_tensors_to_buffer(src_hd_list, src_range, hidden_states_buffer)
-                self.spec_info.hidden_states = self.spec_info.hidden_states[:len(src_hd_list)*draft_steps]
+                self.spec_info.hidden_states = self.spec_info.hidden_states[:self.spec_info.verified_id.numel()]
             else:
                 self.spec_info.hidden_states = torch.cat([seq.hidden_states for seq in self.sequences], dim=0)
             cache_sources = [seq.out_cache_loc_lazy for seq in self.sequences
@@ -167,13 +166,8 @@ class ScheduleBatch:
         spec_kv_indices_list = []
         spec_kv_indptr_list = [0]
         device = self.device
-        for sequence in self.sequences:
-            total_draft_len = len(sequence.new_tokens)
-            if (len(sequence.tokens) == sequence.last_generated_token_pos
-                    and sequence.accept_length_cpu[0].item() < 0):
-                spec_out_cache_loc_list.append(0)
-            else:
-                spec_out_cache_loc_list.extend(sequence.out_cache_loc_spec[-total_draft_len:])
+        for sequence, positions in zip(self.sequences, positions_outs):
+            spec_out_cache_loc_list.extend(sequence.out_cache_loc_spec[positions.start:positions.stop])
             spec_kv_indptr_list.append(spec_kv_indptr_list[-1] + len(sequence.out_cache_loc_spec))
             spec_kv_indices_list.extend(sequence.out_cache_loc_spec)
 

--- a/python/sfllm/engine/schedule_batch.py
+++ b/python/sfllm/engine/schedule_batch.py
@@ -10,6 +10,7 @@ from sfllm.engine.forward_params import ForwardBatch,ForwardMode
 from sfllm.engine.sequence import RequestSequence
 from sfllm.utils.nutils import DEFAULT_CUDA_GRAPH_BATCH_SIZES
 from sfllm.layers.sampler import SamplingBatchInfo
+from sfllm.kernels.triton_utils import compact_accepted_tokens
 from sfllm.server_args import get_global_server_args
 from sfllm.spec_decoding.spec_common import SpecInput
 
@@ -216,6 +217,12 @@ class ScheduleBatch:
                 self.update_spec_info_if_needed(hidden_states_buffer=hidden_states_buffer)
         else:
             self.update_spec_info_if_needed(None)
+            draft = self.forward_batch_spec
+            draft.kv_indices = compact_accepted_tokens(
+                draft.kv_indices, draft.kv_indptr,
+                (draft.kv_indptr - draft.qo_indptr).diff(), fill_value=0,
+            )
+            draft.kv_indptr.sub_(draft.qo_indptr)
 
     def prepare_inputs(self, is_overlap:bool=False):
         cur_seq_lens_list = [0]

--- a/python/sfllm/spec_decoding/dflash2_worker.py
+++ b/python/sfllm/spec_decoding/dflash2_worker.py
@@ -209,8 +209,8 @@ class DFlash2Worker(SpeculativeWorker):
         forward_batch = ForwardBatch(self.draft_mem_pool)
         forward_batch.forward_mode = ForwardMode.DRAFT_EXTEND
         forward_batch.qo_indptr = batch.forward_batch.qo_indptr
-        forward_batch.kv_indptr = batch.forward_batch_spec.kv_indptr
-        forward_batch.kv_indices = batch.forward_batch_spec.kv_indices
+        forward_batch.kv_indptr = batch.forward_batch.kv_indptr
+        forward_batch.kv_indices = batch.forward_batch_spec.kv_indices_mtd
         forward_batch.out_cache_loc = self._draft_scratch_locs[:token_count]
         forward_batch.seq_lens = batch.forward_batch.seq_lens
         forward_batch.max_extend_len = self.block_size

--- a/python/sfllm/spec_decoding/draft_cuda_graph_runner.py
+++ b/python/sfllm/spec_decoding/draft_cuda_graph_runner.py
@@ -19,6 +19,8 @@ class EagleCudaGraphRunner():
         indptr_shape.insert(0, steps)
         indices_shape = list(draft_model_runner.kv_indices_buffer.shape)
         indices_shape.insert(0, steps)
+        max_batch_size = max(self.server_args.max_running_requests, self.server_args.cuda_graph_max_bs)
+        indices_shape[-1] = (indices_shape[-1] + steps * max_batch_size) * self.topk
         self.kv_indptr_buffer = draft_model_runner.kv_indptr_buffer
         self.kv_indptr_buffer_s = torch.zeros(indptr_shape, dtype=torch.int32, device=draft_model_runner.device_id)
         self.kv_indices_buffer_s = torch.zeros(indices_shape, dtype=torch.long, device=draft_model_runner.device_id)

--- a/python/sfllm/spec_decoding/eagle_worker.py
+++ b/python/sfllm/spec_decoding/eagle_worker.py
@@ -15,7 +15,6 @@ from sfllm.spec_decoding.spec_utils import (EagleSpecInput,
                                             generate_kv_indices_for_mtd)
 from sfllm.spec_decoding.draft_cuda_graph_runner import EagleCudaGraphRunner
 from sfllm.spec_decoding.spec_worker import SpeculativeWorker
-from sfllm.kernels.triton_utils import compact_accepted_tokens
 
 ALIGN_EAGLE_WITH_SGLANG_ = False
 logger = logging.getLogger(__name__)
@@ -286,40 +285,30 @@ class EagleWorker(SpeculativeWorker):
         )
 
     def commit_previous(self, scheduled_batch: ScheduleBatch) -> None:
-        """Commit accepted tokens using a prefix that excludes these queries."""
+        """Advance Eagle's draft KV state with the previous accepted tokens."""
+        #decode for the latest token#######################
+        # the first time will be skipped as we have run it in prefill stage
         spec_info = scheduled_batch.spec_info
         if spec_info.hidden_states.shape[-1] == self.target_model_runner.get_config().hidden_size:
             return
+        forward_batch_spec = scheduled_batch.forward_batch_spec
+        old_input_ids = scheduled_batch.input_ids
+        old_position_ids = scheduled_batch.position_ids
 
-        forward_batch = scheduled_batch.forward_batch_spec
-        full_indptr, full_indices = forward_batch.kv_indptr, forward_batch.kv_indices
-        query_indptr = forward_batch.qo_indptr
-        prefix_lens = full_indptr.diff() - query_indptr.diff()
-        prefix_indices = compact_accepted_tokens(
-            full_indices, full_indptr, prefix_lens, fill_value=0,
-        )
-        prefix_indptr = torch.cat((full_indptr[:1], prefix_lens.cumsum(0, dtype=torch.int32)))
+        forward_batch_spec.forward_mode = ForwardMode.DRAFT_EXTEND
+        scheduled_batch.input_ids = spec_info.verified_id  # the real input_ids
+        scheduled_batch.position_ids = scheduled_batch.forward_batch_spec.position_ids_extend # the real position_ids
+        forward_batch_spec.spec_info = spec_info
 
-        target_batch = scheduled_batch.forward_batch
-        input_ids, position_ids = scheduled_batch.input_ids, scheduled_batch.position_ids
-        mode, previous_spec_info = forward_batch.forward_mode, forward_batch.spec_info
-        try:
-            scheduled_batch.forward_batch, scheduled_batch.forward_batch_spec = forward_batch, target_batch
-            scheduled_batch.input_ids = spec_info.verified_id
-            scheduled_batch.position_ids = forward_batch.position_ids_extend
-            forward_batch.forward_mode = ForwardMode.DRAFT_EXTEND
-            forward_batch.spec_info = spec_info
-            forward_batch.kv_indptr, forward_batch.kv_indices = prefix_indptr, prefix_indices
-            with torch.cuda.nvtx.range("commit_previous"):
+        # Run forward
+        with torch.cuda.nvtx.range("commit_previous"):
+            with scheduled_batch.switch_spec_forward_batch():
                 logits_output = self.draft_model_runner.forward(scheduled_batch)
-        finally:
-            scheduled_batch.forward_batch, scheduled_batch.forward_batch_spec = target_batch, forward_batch
-            scheduled_batch.input_ids, scheduled_batch.position_ids = input_ids, position_ids
-            forward_batch.kv_indptr, forward_batch.kv_indices = full_indptr, full_indices
-            forward_batch.forward_mode, forward_batch.spec_info = mode, previous_spec_info
 
-        spec_info.hidden_states = logits_output.aux_hidden_states[0][query_indptr[1:] - 1]
+        spec_info.hidden_states = logits_output.aux_hidden_states[0][(forward_batch_spec.qo_indptr[1:]-1)]
         spec_info.logits = logits_output.next_token_logits
+        scheduled_batch.position_ids = old_position_ids
+        scheduled_batch.input_ids = old_input_ids
 
 
     # why this work???

--- a/python/sfllm/spec_decoding/eagle_worker.py
+++ b/python/sfllm/spec_decoding/eagle_worker.py
@@ -1,6 +1,7 @@
 
 
 import logging
+from copy import copy
 import torch
 from typing import List
 from sfllm.engine.schedule_batch import ScheduleBatch,BatchResult
@@ -15,6 +16,7 @@ from sfllm.spec_decoding.spec_utils import (EagleSpecInput,
                                             generate_kv_indices_for_mtd)
 from sfllm.spec_decoding.draft_cuda_graph_runner import EagleCudaGraphRunner
 from sfllm.spec_decoding.spec_worker import SpeculativeWorker
+from sfllm.kernels.triton_utils import compact_accepted_tokens
 
 ALIGN_EAGLE_WITH_SGLANG_ = False
 logger = logging.getLogger(__name__)
@@ -285,30 +287,38 @@ class EagleWorker(SpeculativeWorker):
         )
 
     def commit_previous(self, scheduled_batch: ScheduleBatch) -> None:
-        """Advance Eagle's draft KV state with the previous accepted tokens."""
-        #decode for the latest token#######################
-        # the first time will be skipped as we have run it in prefill stage
+        """Commit accepted tokens using a prefix that excludes these queries."""
         spec_info = scheduled_batch.spec_info
         if spec_info.hidden_states.shape[-1] == self.target_model_runner.get_config().hidden_size:
             return
-        forward_batch_spec = scheduled_batch.forward_batch_spec
-        old_input_ids = scheduled_batch.input_ids
-        old_position_ids = scheduled_batch.position_ids
 
-        forward_batch_spec.forward_mode = ForwardMode.DRAFT_EXTEND
-        scheduled_batch.input_ids = spec_info.verified_id  # the real input_ids
-        scheduled_batch.position_ids = scheduled_batch.forward_batch_spec.position_ids_extend # the real position_ids
-        forward_batch_spec.spec_info = spec_info
+        draft_batch = copy(scheduled_batch)
+        forward_batch = copy(scheduled_batch.forward_batch_spec)
+        draft_batch.forward_batch = forward_batch
+        draft_batch.input_ids = spec_info.verified_id
+        draft_batch.position_ids = forward_batch.position_ids_extend
+        forward_batch.forward_mode = ForwardMode.DRAFT_EXTEND
+        forward_batch.spec_info = spec_info
 
-        # Run forward
+        # The scheduler's draft indices contain the complete sequence. Extend
+        # reads only its prefix; each query writes to its own logical KV slot.
+        full_indptr = forward_batch.kv_indptr
+        query_indptr = forward_batch.qo_indptr
+        prefix_lens = full_indptr.diff() - query_indptr.diff()
+        rows = torch.arange(draft_batch.input_ids.numel(), device=full_indptr.device)
+        sequence_ids = torch.searchsorted(query_indptr[1:], rows, right=True).clamp_max(len(draft_batch) - 1)
+        valid = rows < query_indptr[-1]
+        cache_offsets = torch.where(valid, full_indptr[sequence_ids] + draft_batch.position_ids, 0)
+        forward_batch.out_cache_loc = torch.where(valid, forward_batch.kv_indices[cache_offsets], 0)
+        forward_batch.kv_indices = compact_accepted_tokens(
+            forward_batch.kv_indices, full_indptr, prefix_lens, fill_value=0,
+        )
+        forward_batch.kv_indptr = torch.cat((full_indptr[:1], prefix_lens.cumsum(0, dtype=torch.int32)))
         with torch.cuda.nvtx.range("commit_previous"):
-            with scheduled_batch.switch_spec_forward_batch():
-                logits_output = self.draft_model_runner.forward(scheduled_batch)
+            logits_output = self.draft_model_runner.forward(draft_batch)
 
-        spec_info.hidden_states = logits_output.aux_hidden_states[0][(forward_batch_spec.qo_indptr[1:]-1)]
+        spec_info.hidden_states = logits_output.aux_hidden_states[0][query_indptr[1:] - 1]
         spec_info.logits = logits_output.next_token_logits
-        scheduled_batch.position_ids = old_position_ids
-        scheduled_batch.input_ids = old_input_ids
 
 
     # why this work???

--- a/python/sfllm/spec_decoding/eagle_worker.py
+++ b/python/sfllm/spec_decoding/eagle_worker.py
@@ -1,7 +1,6 @@
 
 
 import logging
-from copy import copy
 import torch
 from typing import List
 from sfllm.engine.schedule_batch import ScheduleBatch,BatchResult
@@ -292,30 +291,40 @@ class EagleWorker(SpeculativeWorker):
         if spec_info.hidden_states.shape[-1] == self.target_model_runner.get_config().hidden_size:
             return
 
-        draft_batch = copy(scheduled_batch)
-        forward_batch = copy(scheduled_batch.forward_batch_spec)
-        draft_batch.forward_batch = forward_batch
-        draft_batch.input_ids = spec_info.verified_id
-        draft_batch.position_ids = forward_batch.position_ids_extend
-        forward_batch.forward_mode = ForwardMode.DRAFT_EXTEND
-        forward_batch.spec_info = spec_info
-
-        # The scheduler's draft indices contain the complete sequence. Extend
-        # reads only its prefix; each query writes to its own logical KV slot.
-        full_indptr = forward_batch.kv_indptr
+        forward_batch = scheduled_batch.forward_batch_spec
+        full_indptr, full_indices = forward_batch.kv_indptr, forward_batch.kv_indices
         query_indptr = forward_batch.qo_indptr
         prefix_lens = full_indptr.diff() - query_indptr.diff()
-        rows = torch.arange(draft_batch.input_ids.numel(), device=full_indptr.device)
-        sequence_ids = torch.searchsorted(query_indptr[1:], rows, right=True).clamp_max(len(draft_batch) - 1)
+        rows = torch.arange(spec_info.verified_id.numel(), device=full_indptr.device)
+        sequence_ids = torch.searchsorted(query_indptr[1:], rows, right=True).clamp_max(len(scheduled_batch) - 1)
         valid = rows < query_indptr[-1]
-        cache_offsets = torch.where(valid, full_indptr[sequence_ids] + draft_batch.position_ids, 0)
-        forward_batch.out_cache_loc = torch.where(valid, forward_batch.kv_indices[cache_offsets], 0)
-        forward_batch.kv_indices = compact_accepted_tokens(
-            forward_batch.kv_indices, full_indptr, prefix_lens, fill_value=0,
+        cache_offsets = torch.where(valid, full_indptr[sequence_ids] + forward_batch.position_ids_extend, 0)
+        query_cache_locs = torch.where(valid, full_indices[cache_offsets], 0)
+        prefix_indices = compact_accepted_tokens(
+            full_indices, full_indptr, prefix_lens, fill_value=0,
         )
-        forward_batch.kv_indptr = torch.cat((full_indptr[:1], prefix_lens.cumsum(0, dtype=torch.int32)))
-        with torch.cuda.nvtx.range("commit_previous"):
-            logits_output = self.draft_model_runner.forward(draft_batch)
+        prefix_indptr = torch.cat((full_indptr[:1], prefix_lens.cumsum(0, dtype=torch.int32)))
+
+        target_batch = scheduled_batch.forward_batch
+        input_ids, position_ids = scheduled_batch.input_ids, scheduled_batch.position_ids
+        cache_locs = forward_batch.out_cache_loc
+        mode, previous_spec_info = forward_batch.forward_mode, forward_batch.spec_info
+        try:
+            scheduled_batch.forward_batch, scheduled_batch.forward_batch_spec = forward_batch, target_batch
+            scheduled_batch.input_ids = spec_info.verified_id
+            scheduled_batch.position_ids = forward_batch.position_ids_extend
+            forward_batch.forward_mode = ForwardMode.DRAFT_EXTEND
+            forward_batch.spec_info = spec_info
+            forward_batch.kv_indptr, forward_batch.kv_indices = prefix_indptr, prefix_indices
+            forward_batch.out_cache_loc = query_cache_locs
+            with torch.cuda.nvtx.range("commit_previous"):
+                logits_output = self.draft_model_runner.forward(scheduled_batch)
+        finally:
+            scheduled_batch.forward_batch, scheduled_batch.forward_batch_spec = target_batch, forward_batch
+            scheduled_batch.input_ids, scheduled_batch.position_ids = input_ids, position_ids
+            forward_batch.kv_indptr, forward_batch.kv_indices = full_indptr, full_indices
+            forward_batch.out_cache_loc = cache_locs
+            forward_batch.forward_mode, forward_batch.spec_info = mode, previous_spec_info
 
         spec_info.hidden_states = logits_output.aux_hidden_states[0][query_indptr[1:] - 1]
         spec_info.logits = logits_output.next_token_logits

--- a/python/sfllm/spec_decoding/eagle_worker.py
+++ b/python/sfllm/spec_decoding/eagle_worker.py
@@ -295,11 +295,6 @@ class EagleWorker(SpeculativeWorker):
         full_indptr, full_indices = forward_batch.kv_indptr, forward_batch.kv_indices
         query_indptr = forward_batch.qo_indptr
         prefix_lens = full_indptr.diff() - query_indptr.diff()
-        rows = torch.arange(spec_info.verified_id.numel(), device=full_indptr.device)
-        sequence_ids = torch.searchsorted(query_indptr[1:], rows, right=True).clamp_max(len(scheduled_batch) - 1)
-        valid = rows < query_indptr[-1]
-        cache_offsets = torch.where(valid, full_indptr[sequence_ids] + forward_batch.position_ids_extend, 0)
-        query_cache_locs = torch.where(valid, full_indices[cache_offsets], 0)
         prefix_indices = compact_accepted_tokens(
             full_indices, full_indptr, prefix_lens, fill_value=0,
         )
@@ -307,7 +302,6 @@ class EagleWorker(SpeculativeWorker):
 
         target_batch = scheduled_batch.forward_batch
         input_ids, position_ids = scheduled_batch.input_ids, scheduled_batch.position_ids
-        cache_locs = forward_batch.out_cache_loc
         mode, previous_spec_info = forward_batch.forward_mode, forward_batch.spec_info
         try:
             scheduled_batch.forward_batch, scheduled_batch.forward_batch_spec = forward_batch, target_batch
@@ -316,14 +310,12 @@ class EagleWorker(SpeculativeWorker):
             forward_batch.forward_mode = ForwardMode.DRAFT_EXTEND
             forward_batch.spec_info = spec_info
             forward_batch.kv_indptr, forward_batch.kv_indices = prefix_indptr, prefix_indices
-            forward_batch.out_cache_loc = query_cache_locs
             with torch.cuda.nvtx.range("commit_previous"):
                 logits_output = self.draft_model_runner.forward(scheduled_batch)
         finally:
             scheduled_batch.forward_batch, scheduled_batch.forward_batch_spec = target_batch, forward_batch
             scheduled_batch.input_ids, scheduled_batch.position_ids = input_ids, position_ids
             forward_batch.kv_indptr, forward_batch.kv_indices = full_indptr, full_indices
-            forward_batch.out_cache_loc = cache_locs
             forward_batch.forward_mode, forward_batch.spec_info = mode, previous_spec_info
 
         spec_info.hidden_states = logits_output.aux_hidden_states[0][query_indptr[1:] - 1]

--- a/python/sfllm/spec_decoding/spec_e2e_cuda_graph_runner.py
+++ b/python/sfllm/spec_decoding/spec_e2e_cuda_graph_runner.py
@@ -77,7 +77,7 @@ class SpeculativeE2ECudaGraphRunner():
         spec_forward_batch.position_ids_extend = self.spec_position_ids_extend[:token_nums]# position_ids
         spec_forward_batch.out_cache_loc = self.spec_out_cache_loc[:token_nums] 
         spec_forward_batch.kv_indptr = self.spec_kv_indptr_buffer[: batch_size + 1]
-        spec_forward_batch.kv_indices = self.spec_kv_indices_buffer[: batch_size] # ....
+        spec_forward_batch.kv_indices = self.spec_kv_indices_buffer
         spec_forward_batch.qo_indptr = self.spec_qo_indptr_buffer[: batch_size + 1]
         spec_forward_batch.num_kv_splits = self.num_kv_splits_buffer[:batch_size]
         spec_forward_batch.forward_mode = ForwardMode.DRAFT_EXTEND

--- a/python/sfllm/spec_decoding/spec_utils.py
+++ b/python/sfllm/spec_decoding/spec_utils.py
@@ -629,7 +629,7 @@ def generate_kv_indices_for_mtd_triton(kv_out_buffer: Tuple[torch.Tensor, torch.
         assert kv_indptr.shape[0] == running_steps and kv_indptr.is_contiguous()
         kv_indices_stride_0 = kv_indices.stride(0)
         kv_indptr_stride_0 = kv_indptr.stride(0)
-        assert (seq_lens_sum + (running_steps - 1 + 1) * bs) * topk < kv_indices_stride_0
+        assert (seq_lens_sum + (running_steps - 1 + 1) * bs) * topk <= kv_indices_stride_0
     else:
         kv_indptr = torch.zeros((running_steps*(topk*bs+1),), dtype=torch.int32, device=device)
         kv_indices = torch.empty(


### PR DESCRIPTION
Fix EAGLE3 decode instability caused by incorrect KV prefixes/write addresses and undersized top-k index buffers. Prepare the correct KV layouts and token-row counts before forward; DFlash2 proposal continues to use complete KV history.

Validation on 22 Polaris prompts capped at 64 output tokens:

- FA3/Triton × overlap on/off × CUDA Graph on/off: all eight configurations preserve tokens and acceptance traces against `c84902f`. Qwen3.5 + DFlash2 also remains bitexact.
- Repeated runs and slot-0 NaN injection preserve results; no valid query or visible KV entry uses slot 0. Server counters match the streaming responses in the 500-request runs.

- Non-spec: Qwen3-0.6B across all eight modes, plus Qwen3.5 (FA3, FP32 SSM), match main in tokens, batch order and counters.

Polaris500 on H100 NVL, Qwen3-0.6B + EAGLE3 BF16: concurrency 22, top-k 4, four draft steps, eight verify tokens, greedy, max output 1000, overlap + CUDA Graph enabled. Main: `0fb4ebf`; PR: `0cfe0a0`.

| Version | Backend | QPS | Acclen | Output tok/s | Success/Fail |
|---|---|---:|---:|---:|---:|
| main | FA3 | — | — | — | Incomplete |
| PR | FA3 | 7.1010 | 1.9417 | 2969.84 | 500/0 |
| main | Triton | 2.3474 | 1.8224 | 975.16 | 500/0 |
| PR | Triton | 2.4723 | 1.9431 | 1016.76 | 500/0 |

Main/FA3 stalled twice; the second attempt exceeded 300 seconds. Acclen excludes the prefill token.
