### PR TITLE
perf: optimize shared logits argmax and draft selector

### DIFF
--- a/python/sfllm/kernels/dflash2.py
+++ b/python/sfllm/kernels/dflash2.py
@@ -53,7 +53,8 @@ def prepare_dflash2_block(
 @triton.jit
 def _selector_greedy_walk_kernel(
     candidate_ids,
-    scores,
+    unary_logits,
+    pairwise,
     proposals_out,
     slots: tl.constexpr,
     top_k: tl.constexpr,
@@ -66,10 +67,15 @@ def _selector_greedy_walk_kernel(
     for slot in range(slots):
         score_offset = ((row * slots + slot) * top_k + predecessor) * top_k
         values = tl.load(
-            scores + score_offset + offsets,
+            pairwise + score_offset + offsets,
             mask=valid,
             other=-float("inf"),
-        )
+        ).to(tl.float32)
+        unary = tl.load(
+            unary_logits + (row * slots + slot) * top_k + offsets,
+            mask=valid, other=0,
+        ).to(tl.float32)
+        values = unary + values
         best = tl.max(values, axis=0)
         selected = tl.min(tl.where(values == best, offsets, top_k), axis=0)
         token_offset = (row * slots + slot) * top_k + selected
@@ -82,13 +88,15 @@ def _selector_greedy_walk_kernel(
 
 def dflash2_selector_greedy_walk(
     candidate_ids: torch.Tensor,
-    scores: torch.Tensor,
+    unary_logits: torch.Tensor,
+    pairwise: torch.Tensor,
     proposals_out: torch.Tensor,
 ) -> None:
     batch_size, slots, top_k = candidate_ids.shape
     _selector_greedy_walk_kernel[(batch_size,)](
         candidate_ids,
-        scores,
+        unary_logits,
+        pairwise,
         proposals_out,
         slots=slots,
         top_k=top_k,

--- a/python/sfllm/kernels/sampling.py
+++ b/python/sfllm/kernels/sampling.py
@@ -1,0 +1,81 @@
+"""Argmax over vocabulary logits, optionally fused with an addition."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _maximum_propagate_nan(a, b):
+    return tl.maximum(a, b, propagate_nan=tl.PropagateNan.ALL)
+
+
+@triton.jit
+def _argmax_partial_kernel(
+    logits_ptr, addend_ptr, partial_values, partial_indices,
+    vocab_size: tl.constexpr, logits_row_stride: tl.constexpr,
+    addend_row_stride: tl.constexpr, HAS_ADDEND: tl.constexpr,
+    PARTS: tl.constexpr, BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    part = tl.program_id(1)
+    col = part * BLOCK + tl.arange(0, BLOCK)
+    x = tl.load(logits_ptr + row * logits_row_stride + col, col < vocab_size, other=-float('inf'))
+    value = x.to(tl.float32)
+    if HAS_ADDEND:
+        addend = tl.load(addend_ptr + row * addend_row_stride + col, col < vocab_size, other=0).to(tl.float32)
+        value = (value + addend).to(x.dtype).to(tl.float32)
+    best = tl.reduce(value, 0, _maximum_propagate_nan)
+    same = tl.where(best != best, value != value, value == best)
+    index = tl.min(tl.where(same & (col < vocab_size), col, 2147483647), 0)
+    tl.store(partial_values + row * PARTS + part, best)
+    tl.store(partial_indices + row * PARTS + part, index)
+
+
+@triton.jit
+def _argmax_merge_kernel(
+    partial_values, partial_indices, output_ptr, output_stride: tl.constexpr,
+    PARTS: tl.constexpr, BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    part = tl.arange(0, BLOCK)
+    value = tl.load(partial_values + row * PARTS + part, part < PARTS, other=-float('inf'))
+    index = tl.load(partial_indices + row * PARTS + part, part < PARTS, other=2147483647)
+    best = tl.reduce(value, 0, _maximum_propagate_nan)
+    same = tl.where(best != best, value != value, value == best)
+    chosen = tl.min(tl.where(same, index, 2147483647), 0)
+    tl.store(output_ptr + row * output_stride, chosen)
+
+
+def logits_argmax(x: torch.Tensor, addend: torch.Tensor = None,
+                  out: torch.Tensor = None) -> torch.Tensor:
+    """Compute ``x.argmax(-1)`` or ``(x + addend).argmax(-1)``, including ties and NaNs.
+
+    The optional addition rounds to the logits dtype before reduction. Large
+    vocabularies are split across CTAs; only partial maxima reach global memory.
+    ``out`` may be strided and is also returned.
+    """
+    if (not x.is_cuda or x.ndim != 2 or x.stride(-1) != 1
+            or x.shape[-1] < 4096 or x.shape[0] == 0
+            or x.dtype not in (torch.float16, torch.bfloat16, torch.float32)
+            or (addend is not None and (addend.shape != x.shape or addend.dtype != x.dtype
+                                        or addend.stride(-1) != 1))):
+        result = (x if addend is None else x + addend).argmax(-1)
+        return result if out is None else out.copy_(result)
+    batch, vocab = x.shape
+    block = 4096 if addend is None else 2048
+    parts = triton.cdiv(vocab, block)
+    partial_values = torch.empty((batch, parts), device=x.device, dtype=torch.float32)
+    partial_indices = torch.empty((batch, parts), device=x.device, dtype=torch.int32)
+    if out is None:
+        out = torch.empty(batch, device=x.device, dtype=torch.int64)
+    _argmax_partial_kernel[(batch, parts)](
+        x, addend, partial_values, partial_indices, vocab, x.stride(0),
+        0 if addend is None else addend.stride(0), addend is not None,
+        parts, block, num_warps=4,
+    )
+    _argmax_merge_kernel[(batch,)](
+        partial_values, partial_indices, out, out.stride(0), parts,
+        triton.next_power_of_2(parts), num_warps=4,
+    )
+    return out

--- a/python/sfllm/models/dflash2.py
+++ b/python/sfllm/models/dflash2.py
@@ -305,10 +305,9 @@ class DFlash2CandidateSelector(nn.Module):
         )
         self.hidden_projection = nn.Linear(hidden_size, state_rank, bias=False)
 
-    def build_lattice(
+    def compute_pairwise_scores(
         self,
         candidate_ids: torch.Tensor,
-        unary_logits: torch.Tensor,
         hidden_states: torch.Tensor,
         anchor_token_ids: torch.Tensor,
     ) -> torch.Tensor:
@@ -322,10 +321,9 @@ class DFlash2CandidateSelector(nn.Module):
             dim=1,
         )
         predecessors = self.predecessor_codebook[predecessor_ids]
-        pairwise = torch.einsum(
+        return torch.einsum(
             "blpr,blcr->blpc", predecessors * hidden[:, :, None], successors
         )
-        return unary_logits[:, :, None, :] + pairwise.float()
 
 
 class DFlash2DraftModel(nn.Module):

--- a/python/sfllm/spec_decoding/dflash2_worker.py
+++ b/python/sfllm/spec_decoding/dflash2_worker.py
@@ -271,16 +271,16 @@ class DFlash2Worker(SpeculativeWorker):
         )
         top_k = self.dflash2_config.selector_top_k
         candidate_ids = candidate_ids.view(batch_size, block - 1, top_k)
-        selector_scores = (
-            self.draft_model_runner.model.candidate_selector.build_lattice(
+        pairwise = (
+            self.draft_model_runner.model.candidate_selector.compute_pairwise_scores(
                 candidate_ids=candidate_ids,
-                unary_logits=unary_logits.view(batch_size, block - 1, top_k),
                 hidden_states=prediction_hidden,
                 anchor_token_ids=self._block_ids[:batch_size, 0],
             )
         )
         dflash2_selector_greedy_walk(
-            candidate_ids, selector_scores, self._proposals[:batch_size]
+            candidate_ids, unary_logits.view(batch_size, block - 1, top_k),
+            pairwise, self._proposals[:batch_size],
         )
 
         candidates = self._candidates[:batch_size]

--- a/python/sfllm/spec_decoding/spec_utils.py
+++ b/python/sfllm/spec_decoding/spec_utils.py
@@ -6,6 +6,7 @@ import math
 import triton
 import triton.language as tl
 from sfllm.kernels.triton_utils import move_neg1_to_tail
+from sfllm.kernels.sampling import logits_argmax
 
 import sf_kernel
 from sfllm.spec_decoding.spec_common import SpecInput, SpecInputType
@@ -109,7 +110,7 @@ class EagleVerifyInput(SpecInput):
         # Sample tokens. Force greedy sampling on AMD
         is_all_greedy = True#sampling_info.is_all_greedy
         if is_all_greedy:
-            target_predict = torch.argmax(logits_output.next_token_logits, dim=-1)
+            target_predict = logits_argmax(logits_output.next_token_logits)
             target_predict = target_predict.reshape(bs, self.draft_token_num)
 
             sf_kernel.verify_tree_greedy(


### PR DESCRIPTION
Reduce greedy sampling overhead with shared `logits_argmax`, including optional fused addition, and use it in target verification. Fuse the selector score addition into its existing greedy walk. Five files; existing selector GEMM and argmax dtype rounding are unchanged.

The selector keeps scores in FP32. DFlash2 already used FP32 scores. Compared with the local DSpark top-k BF16 path, this intentionally changes rounding/tie decisions: 8/550 proposal tokens differ in the head comparison. DSpark model support is separate from this PR.

Validation on H100 NVL, Qwen3.5, SSM FP32, concurrency 22, overlap + CUDA Graph:

- Worktree DFlash2: five decode steps, 550 target argmax rows match PyTorch. Five real selector inputs plus 40 boundary cases match the original implementation: 25,395 FP32 score values and 1,595 proposal tokens are bitexact.
- The byte-identical argmax helper previously matched PyTorch on 57,123 actual target/draft rows, including fused addition.

Five-step nsys measurements, mean GPU kernel time per decode step:

| Operation | Before (μs) | After (μs) |
|---|---:|---:|
| Target verify argmax, 132 rows | 55.917 | 32.910 |
| Draft addition + argmax, 5 × 22 rows | 177.801 | 51.726 |
| DFlash2 selector cast + add + walk | 7.322 | 2.669 |

Argmax timings use the existing DSpark integration with this identical helper. Selector timings replay five real inputs captured from the PR worktree. These are operator timings, not serving-throughput measurements or end-to-end output-equivalence claims.
