### PR TITLE
feat: propagate sliding windows through attention

### DIFF
--- a/python/sfllm/kernels/decode_attention.py
+++ b/python/sfllm/kernels/decode_attention.py
@@ -65,6 +65,7 @@ def _fwd_kernel_stage1(
     BLOCK_N: tl.constexpr,
     MIN_BLOCK_KV: tl.constexpr,
     logit_cap: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
     Lk: tl.constexpr,
     Lv: tl.constexpr,
     xai_temperature_len: tl.constexpr,
@@ -91,6 +92,11 @@ def _fwd_kernel_stage1(
         xai_temperature_reg = tl.where(offs_qidx > xai_temperature_len, _qtemp, 1.0)
 
     off_q = cur_batch * stride_qbs + cur_head * stride_qh + offs_d
+
+    if WINDOW_SIZE[0] >= 0:
+        window_start = tl.maximum(cur_batch_seq_len - WINDOW_SIZE[0] - 1, 0)
+        cur_batch_kv_start_idx += window_start
+        cur_batch_seq_len -= window_start
 
     kv_len_per_split = (
         tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
@@ -190,6 +196,7 @@ def _decode_att_m_fwd(
     sm_scale,
     logit_cap,
     xai_temperature_len=-1,
+    window_size: tuple[int, int] = (-1, -1),
 ):
     BLOCK = 64
     # [TODO] work around SGPR limit on MI3xx
@@ -239,6 +246,7 @@ def _decode_att_m_fwd(
         BLOCK_N=BLOCK,
         MIN_BLOCK_KV=_MIN_BLOCK_KV,
         logit_cap=logit_cap,
+        WINDOW_SIZE=window_size,
         xai_temperature_len=xai_temperature_len,
         num_warps=num_warps,
         num_stages=2,
@@ -276,6 +284,7 @@ def _fwd_grouped_kernel_stage1(
     BLOCK_H: tl.constexpr,
     MIN_BLOCK_KV: tl.constexpr,
     logit_cap: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
     xai_temperature_len: tl.constexpr,
     Lk: tl.constexpr,
     Lv: tl.constexpr,
@@ -316,6 +325,11 @@ def _fwd_grouped_kernel_stage1(
         off_qpe = (
             cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_dpe[None, :]
         )
+
+    if WINDOW_SIZE[0] >= 0:
+        window_start = tl.maximum(cur_batch_seq_len - WINDOW_SIZE[0] - 1, 0)
+        cur_batch_kv_start_idx += window_start
+        cur_batch_seq_len -= window_start
 
     kv_len_per_split = (
         tl.cdiv(tl.cdiv(cur_batch_seq_len, kv_splits), MIN_BLOCK_KV) * MIN_BLOCK_KV
@@ -618,6 +632,7 @@ def _decode_grouped_att_m_fwd(
     sm_scale,
     logit_cap,
     xai_temperature_len=-1,
+    window_size: tuple[int, int] = (-1, -1),
 ):
     BLOCK = 32
     Lk = k_buffer.shape[-1]
@@ -718,6 +733,7 @@ def _decode_grouped_att_m_fwd(
         BLOCK_H=BLOCK_H,
         MIN_BLOCK_KV=_MIN_BLOCK_KV,
         logit_cap=logit_cap,
+        WINDOW_SIZE=window_size,
         xai_temperature_len=xai_temperature_len,
         num_warps=4,
         num_stages=num_stages,
@@ -745,6 +761,7 @@ def _fwd_kernel_stage2(
     BLOCK_DV: tl.constexpr,
     Lv: tl.constexpr,
     HAS_SINK: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -752,6 +769,8 @@ def _fwd_kernel_stage2(
     cur_batch_seq_len = tl.load(kv_indptr + cur_batch + 1) - tl.load(
         kv_indptr + cur_batch
     )
+    if WINDOW_SIZE[0] >= 0:
+        cur_batch_seq_len = tl.minimum(cur_batch_seq_len, WINDOW_SIZE[0] + 1)
     kv_splits = tl.load(num_kv_splits + cur_batch)
 
     offs_d = tl.arange(0, BLOCK_DV)
@@ -859,6 +878,7 @@ def _decode_softmax_reducev_fwd(
     num_kv_splits,
     max_kv_splits,
     sinks=None,
+    window_size: tuple[int, int] = (-1, -1),
 ):
     batch, head_num = q.shape[0], q.shape[1]
     Lv = v_buffer.shape[-1]
@@ -891,6 +911,7 @@ def _decode_softmax_reducev_fwd(
         BLOCK_DV=BLOCK_DV,
         Lv=Lv,
         HAS_SINK=HAS_SINK,
+        WINDOW_SIZE=window_size,
         num_warps=4,
         num_stages=2,
         **extra_kargs,
@@ -912,6 +933,7 @@ def decode_attention_fwd_normal(
     logit_cap=0.0,
     sinks=None,
     xai_temperature_len=-1,
+    window_size: tuple[int, int] = (-1, -1),
 ):
     _decode_att_m_fwd(
         q,
@@ -926,6 +948,7 @@ def decode_attention_fwd_normal(
         sm_scale,
         logit_cap,
         xai_temperature_len,
+        window_size=window_size,
     )
     _decode_softmax_reducev_fwd(
         attn_logits,
@@ -937,6 +960,7 @@ def decode_attention_fwd_normal(
         num_kv_splits,
         max_kv_splits,
         sinks,
+        window_size=window_size,
     )
 
 
@@ -955,6 +979,7 @@ def decode_attention_fwd_grouped(
     logit_cap=0.0,
     sinks=None,
     xai_temperature_len=-1,
+    window_size: tuple[int, int] = (-1, -1),
 ):
     _decode_grouped_att_m_fwd(
         q,
@@ -969,6 +994,7 @@ def decode_attention_fwd_grouped(
         sm_scale,
         logit_cap,
         xai_temperature_len,
+        window_size=window_size,
     )
     _decode_softmax_reducev_fwd(
         attn_logits,
@@ -980,6 +1006,7 @@ def decode_attention_fwd_grouped(
         num_kv_splits,
         max_kv_splits,
         sinks,
+        window_size=window_size,
     )
 
 
@@ -998,6 +1025,7 @@ def decode_attention_fwd(
     logit_cap=0.0,
     sinks=None,
     xai_temperature_len=-1,
+    window_size: tuple[int, int] = (-1, -1),
 ):
     assert max_kv_splits == attn_logits.shape[2]
     assert q.shape[0] <= kv_indptr.shape[0] - 1
@@ -1022,6 +1050,7 @@ def decode_attention_fwd(
             logit_cap=logit_cap,
             sinks=sinks,
             xai_temperature_len=xai_temperature_len,
+            window_size=window_size,
         )
     else:
         # GQA/MQA/MLA
@@ -1040,4 +1069,5 @@ def decode_attention_fwd(
             logit_cap=logit_cap,
             sinks=sinks,
             xai_temperature_len=xai_temperature_len,
+            window_size=window_size,
         )

--- a/python/sfllm/kernels/extend_attention.py
+++ b/python/sfllm/kernels/extend_attention.py
@@ -62,7 +62,7 @@ def _fwd_kernel(
     stride_buf_kh,
     stride_buf_vbs,
     stride_buf_vh,
-    SLIDING_WINDOW_SIZE: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
     logit_cap: tl.constexpr,
     xai_temperature_len: tl.constexpr,
     Lq: tl.constexpr,
@@ -94,7 +94,7 @@ def _fwd_kernel(
 
     # For SWA, we should only load the mask in the sliding window
     window_kv_offset = 0
-    if USE_CUSTOM_MASK and SLIDING_WINDOW_SIZE > 0:
+    if USE_CUSTOM_MASK and window_kv_offset_ptr is not None:
         window_kv_offset = tl.load(window_kv_offset_ptr + cur_seq)
 
     offs_d = tl.arange(0, BLOCK_DMODEL)
@@ -159,16 +159,16 @@ def _fwd_kernel(
                 other=0,
             )
             final_mask &= custom_mask
-        if SLIDING_WINDOW_SIZE > 0:
-            # Add mask where q_id <= kv_id + sliding_window_size
+        if WINDOW_SIZE[0] >= 0:
+            # Add mask where q_id <= kv_id + window_size
             # q_id = prefix_len + cur_m, kv_id = cur_n
             window_mask = (
                 cur_seq_len_prefix + cur_block_m * BLOCK_M + offs_m[:, None]
-            ) <= (start_n + offs_n[None, :] + SLIDING_WINDOW_SIZE)
+            ) <= (start_n + offs_n[None, :] + WINDOW_SIZE[0])
             final_mask &= window_mask
 
         SKIP_TILE = False
-        if (USE_CUSTOM_MASK and not SKIP_PREFIX_CUSTOM_MASK) or SLIDING_WINDOW_SIZE > 0:
+        if (USE_CUSTOM_MASK and not SKIP_PREFIX_CUSTOM_MASK) or WINDOW_SIZE[0] >= 0:
             SKIP_TILE = tl.max(tl.max(final_mask.to(tl.int32), axis=1), axis=0) == 0
 
         if not SKIP_TILE:
@@ -273,15 +273,19 @@ def _fwd_kernel(
             mask_non_causal = mask_m[:, None] & mask_n[None, :]
             final_mask &= mask_non_causal
 
-        if SLIDING_WINDOW_SIZE > 0:
-            # Add mask where q_id <= kv_id + sliding_window_size
+        if WINDOW_SIZE[0] >= 0:
+            # Add mask where q_id <= kv_id + window_size
             window_mask = (cur_block_m * BLOCK_M + offs_m[:, None]) <= (
-                start_n + offs_n[None, :] + SLIDING_WINDOW_SIZE
+                start_n + offs_n[None, :] + WINDOW_SIZE[0]
             )
             final_mask &= window_mask
+        if WINDOW_SIZE[1] >= 0:
+            final_mask &= (start_n + offs_n[None, :]) <= (
+                cur_block_m * BLOCK_M + offs_m[:, None] + WINDOW_SIZE[1]
+            )
 
         SKIP_TILE = False
-        if USE_CUSTOM_MASK or SLIDING_WINDOW_SIZE > 0:
+        if USE_CUSTOM_MASK or WINDOW_SIZE != (-1, -1):
             SKIP_TILE = tl.max(tl.max(final_mask.to(tl.int32), axis=1), axis=0) == 0
 
         if not SKIP_TILE:
@@ -381,7 +385,7 @@ def extend_attention_fwd(
     sm_scale=None,
     logit_cap=0.0,
     skip_prefix_custom_mask=True,
-    sliding_window_size=-1,
+    window_size: tuple[int, int] = (-1, -1),
     sinks=None,
     window_kv_offsets=None,
     xai_temperature_len=-1,
@@ -489,7 +493,7 @@ def extend_attention_fwd(
         k_buffer.stride(1),
         v_buffer.stride(0),
         v_buffer.stride(1),
-        SLIDING_WINDOW_SIZE=sliding_window_size,
+        WINDOW_SIZE=window_size,
         logit_cap=logit_cap,
         xai_temperature_len=xai_temperature_len,
         BLOCK_DMODEL=BLOCK_DMODEL,
@@ -519,7 +523,7 @@ def extend_attention_fwd_torch(
     qo_indptr: torch.Tensor,  # [B+1]
     kv_indptr: torch.Tensor,  # [B+1]
     kv_indices: torch.Tensor,  # [prefix_tokens]
-    sliding_window_size: int,
+    window_left: int,
 ):
     B = qo_indptr.size(0) - 1
     _, H_Q, D = q.shape
@@ -566,8 +570,8 @@ def extend_attention_fwd_torch(
         causal_mask = pos_keys.unsqueeze(0) <= t.unsqueeze(1)
 
         # sliding window
-        if sliding_window_size is not None and sliding_window_size > 0:
-            start = (t - (sliding_window_size)).clamp_min(0)  # [extend_len]
+        if window_left is not None and window_left > 0:
+            start = (t - (window_left)).clamp_min(0)  # [extend_len]
         else:
             start = torch.zeros_like(t)
         window_mask = pos_keys.unsqueeze(0) >= start.unsqueeze(1)
@@ -664,7 +668,7 @@ def _test_extend_attention_sliding_window_once(
             is_causal=True,
             mask_indptr=None,
             max_len_extend=max_len_extend,
-            sliding_window_size=WINDOW_SIZE,
+            window_size=(WINDOW_SIZE, 0),
         )
 
         extend_attention_fwd_torch(

--- a/python/sfllm/layers/triton_attention.py
+++ b/python/sfllm/layers/triton_attention.py
@@ -95,7 +95,7 @@ class TritonAttention:
         sm_scale = layer.scaling
         logit_cap=0.0
         skip_prefix_custom_mask=True
-        sliding_window_size=-1
+        window_size=layer.window_size
         sinks=None
         window_kv_offsets=None
         xai_temperature_len=-1
@@ -128,7 +128,7 @@ class TritonAttention:
             sm_scale,
             logit_cap,
             skip_prefix_custom_mask,
-            sliding_window_size,
+            window_size,
             sinks,
             window_kv_offsets,
             xai_temperature_len,
@@ -161,6 +161,7 @@ class TritonAttention:
             forward_batch.num_kv_splits,
             forward_batch.max_kv_splits,
             layer.scaling,
+            window_size=layer.window_size,
         )
         return o
 

--- a/python/sfllm/models/dflash2.py
+++ b/python/sfllm/models/dflash2.py
@@ -113,8 +113,6 @@ class DFlash2Attention(Qwen3Attention):
     def __init__(self, config, layer_id: int, quant_config=None, prefix: str = ""):
         rope = getattr(config, "rope_parameters", None) or {}
         sliding = config.layer_types[layer_id] == "sliding_attention"
-        is_causal = self.attention_is_causal(config, sliding)
-        window = int(config.sliding_window) - 1 if sliding else -1
         super().__init__(
             hidden_size=int(config.hidden_size),
             num_heads=int(config.num_attention_heads),
@@ -129,8 +127,8 @@ class DFlash2Attention(Qwen3Attention):
             attention_bias=bool(config.attention_bias),
             prefix=prefix,
             alt_stream=None,
-            is_causal=is_causal,
-            window_size=(window, 0 if sliding and is_causal else window),
+            is_causal=self.attention_is_causal(config, sliding),
+            window_size=config.window_size if sliding else (-1, -1),
         )
 
     @staticmethod
@@ -334,6 +332,14 @@ class DFlash2DraftModel(nn.Module):
         del prefix
         self.config = config
         self.dflash_config = DFlash2Config.from_hf_config(config)
+        window = (
+            int(config.sliding_window) - 1
+            if "sliding_attention" in config.layer_types else -1
+        )
+        config.window_size = (
+            window,
+            0 if window >= 0 and DFlash2Attention.attention_is_causal(config, True) else window,
+        )
         hidden_size = int(config.hidden_size)
         self.layers = nn.ModuleList(
             [


### PR DESCRIPTION
Propagate per-layer sliding windows through Triton extend/decode, including KV read and reduction bounds. Centralize DFlash2 window configuration and preserve `(-1, -1)` full attention.

Validated on H100 NVL (`2c47690` → `3d6baff`):

- 236 FP16/BF16 GPU checks and 36 DFlash2 configuration checks passed.
- 44 requests / 5,632 output token IDs matched exactly; DFlash2 acceptance matched. Triton output logits were byte-identical (max error 0).
- CUDA graph decode verified; Triton batch 22 pads to 24 with zero eager fallback.

| Model (overlap + CUDA graph) | Median output tok/s, main → PR | Change |
| --- | --- | --- |
| Qwen3.5 + DFlash2 | 1499.66 → 1492.30 | −0.49% |
| Qwen3-0.6B / Triton | 1352.43 → 1351.83 | −0.045% |

Timing: 3 rounds/revision for DFlash2; 6 for Triton with reversed process order. End-to-end coverage uses FA3 sliding attention and Triton full attention; Triton sliding windows are covered by kernel tests.
