### PR TITLE
perf: accelerate GDN prefill and BF16 verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,8 @@ to use the checkpoint default. The selector top-k stays as configured in the che
 
 For Qwen3.5, `--mamba-ssm-dtype bfloat16` explicitly selects BF16 recurrent
 states. The default uses the model config's SSM dtype, or FP32 if unspecified.
-GDN honors the selected prefill/decode backends; unsupported configurations
-raise an error. For BF16 speculative verification, select
-`--linear-attn-decode-backend triton`; SFLLM's FlashInfer verification path
-requires FP32 states.
+GDN prefill and ordinary decode use their selected backends. BF16 speculative
+verification always uses Triton and needs no backend setting.
 
 ### 2. Test the API
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ to use the checkpoint default. The selector top-k stays as configured in the che
 
 For Qwen3.5, `--mamba-ssm-dtype bfloat16` explicitly selects BF16 recurrent
 states. The default uses the model config's SSM dtype, or FP32 if unspecified.
+GDN honors the selected prefill/decode backends; unsupported configurations
+raise an error. For BF16 speculative verification, select
+`--linear-attn-decode-backend triton`; SFLLM's FlashInfer verification path
+requires FP32 states.
 
 ### 2. Test the API
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ For a compatible Qwen3.5 DFlash2 draft, add:
 The draft token count is configurable (2 to the checkpoint block size); omit it
 to use the checkpoint default. The selector top-k stays as configured in the checkpoint.
 
+For Qwen3.5, `--mamba-ssm-dtype bfloat16` explicitly selects BF16 recurrent
+states. The default uses the model config's SSM dtype, or FP32 if unspecified.
+
 ### 2. Test the API
 
 **Chat Completions (Streaming)**

--- a/python/sfllm/kernels/gdn.py
+++ b/python/sfllm/kernels/gdn.py
@@ -7,6 +7,9 @@ from typing import Tuple
 import torch
 import triton
 import triton.language as tl
+from fla.ops.gated_delta_rule.chunk import chunk_gated_delta_rule_fwd
+from flashinfer import gdn_decode
+from flashinfer.gdn_prefill import chunk_gated_delta_rule
 from triton.experimental import gluon as tg
 from triton.experimental.gluon import language as gl
 import sf_kernel
@@ -29,7 +32,7 @@ def _split_l2norm_qkv_gates_kernel(
     block_k: gl.constexpr, log_g: gl.constexpr,
 ):
     # Coalesce convolution loads and state writes along the head dimension.
-    layout: gl.constexpr = gl.BlockedLayout([1, 4], [1, 32], [gl.num_warps(), 1], [1, 0])
+    layout: gl.constexpr = gl.BlockedLayout([1, 4], [1, 32], [4, 1], [1, 0])
     head = gl.program_id(0)
     d = gl.arange(0, block_k, layout=gl.SliceLayout(0, layout))
     if head < num_k_heads:
@@ -142,7 +145,7 @@ def split_l2norm_qkv_gates(
     v = mixed_qkv.new_empty((num_tokens, num_v_heads, head_v_dim))
     g = torch.empty_like(a, dtype=torch.float32)
     beta = torch.empty_like(b, dtype=torch.float32)
-    block_t = 16
+    block_t = 32
     grid = (2 * num_k_heads + num_v_heads, triton.cdiv(num_tokens, block_t) + query_start_loc.shape[0] - 1)
     _split_l2norm_qkv_gates_kernel[grid](
         mixed_qkv,
@@ -170,7 +173,7 @@ def split_l2norm_qkv_gates(
         block_t=block_t,
         block_k=triton.next_power_of_2(max(head_k_dim, head_v_dim)),
         log_g=log_g,
-        num_warps=2,
+        num_warps=4,
         num_stages=3,
     )
     return q, k, v, g, beta
@@ -788,8 +791,6 @@ def packed_gdn_prefill(
     Intermediates and the state pool both use V-first layout.
     cu_seqlens must be immutable for the forward; FLA caches its chunk indices.
     """
-    from fla.ops.gated_delta_rule.chunk import chunk_gated_delta_rule_fwd
-
     _, output, _, final_state, _, _ = chunk_gated_delta_rule_fwd(
         q=q.unsqueeze(0), k=k.unsqueeze(0), v=v.unsqueeze(0),
         g=log_g.unsqueeze(0), beta=beta.unsqueeze(0), scale=q.shape[-1] ** -0.5,
@@ -809,14 +810,6 @@ class GatedDeltaNetBackend:
             raise ValueError("GDN backends must be one of: flashinfer, triton")
         self.prefill_backend = prefill_backend
         self.decode_backend = decode_backend
-        if prefill_backend == "flashinfer":
-            from flashinfer.gdn_prefill import chunk_gated_delta_rule
-
-            self._gdn_prefill = chunk_gated_delta_rule
-        if decode_backend == "flashinfer":
-            from flashinfer import gdn_decode
-
-            self._gdn_decode = gdn_decode
 
     def prefill(
         self,
@@ -881,7 +874,7 @@ class GatedDeltaNetBackend:
             (state_indices.shape[0], *ssm_states.shape[1:]),
             dtype=torch.float32, device=ssm_states.device,
         )
-        output, output_state = self._gdn_prefill(
+        output, output_state = chunk_gated_delta_rule(
             q=q,
             k=k,
             v=v,
@@ -946,9 +939,9 @@ class GatedDeltaNetBackend:
             )
         else:
             recurrent = (
-                self._gdn_decode.gated_delta_rule_mtp
+                gdn_decode.gated_delta_rule_mtp
                 if ssm_output_indices is not None
-                else self._gdn_decode.gated_delta_rule_decode_pretranspose
+                else gdn_decode.gated_delta_rule_decode_pretranspose
             )
             state_options = (
                 dict(ssm_state_indices=ssm_output_indices, disable_state_update=False)

--- a/python/sfllm/kernels/gdn.py
+++ b/python/sfllm/kernels/gdn.py
@@ -60,10 +60,10 @@ def _split_l2norm_qkv_gates_kernel(
     num_k_heads: gl.constexpr, num_v_heads: gl.constexpr,
     head_k_dim: gl.constexpr, head_v_dim: gl.constexpr,
     kernel_width: gl.constexpr, block_t: gl.constexpr,
-    block_k: gl.constexpr,
+    block_k: gl.constexpr, log_g: gl.constexpr,
 ):
     # Coalesce convolution loads and state writes along the head dimension.
-    layout: gl.constexpr = gl.BlockedLayout([1, 4], [1, 32], [4, 1], [1, 0])
+    layout: gl.constexpr = gl.BlockedLayout([1, 4], [1, 32], [gl.num_warps(), 1], [1, 0])
     head = gl.program_id(0)
     d = gl.arange(0, block_k, layout=gl.SliceLayout(0, layout))
     if head < num_k_heads:
@@ -147,7 +147,8 @@ def _split_l2norm_qkv_gates_kernel(
             softplus = gl.where(softplus_input <= 20.0,
                                 gl.log(1.0 + gl.exp(softplus_input)), softplus_input)
             gate_offset = token * num_v_heads + head
-            gl.store(g + gate_offset, gl.exp(-gl.exp(decay) * softplus), mask=token_mask)
+            gate = -gl.exp(decay) * softplus
+            gl.store(g + gate_offset, gate if log_g else gl.exp(gate), mask=token_mask)
             gl.store(beta + gate_offset, (1.0 / (1.0 + gl.exp(-b_value))).to(b.dtype.element_ty), mask=token_mask)
 
 
@@ -166,6 +167,7 @@ def split_l2norm_qkv_gates(
     conv_states: torch.Tensor,
     query_start_loc: torch.Tensor,
     state_indices: torch.Tensor,
+    log_g: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Fuse packed prefill convolution, QK normalization and GDN gates."""
     num_tokens = mixed_qkv.shape[0]
@@ -174,7 +176,7 @@ def split_l2norm_qkv_gates(
     v = mixed_qkv.new_empty((num_tokens, num_v_heads, head_v_dim))
     g = torch.empty_like(a, dtype=torch.float32)
     beta = torch.empty_like(b, dtype=torch.float32)
-    block_t = 32
+    block_t = 16
     grid = (2 * num_k_heads + num_v_heads, triton.cdiv(num_tokens, block_t) + query_start_loc.shape[0] - 1)
     _split_l2norm_qkv_gates_kernel[grid](
         mixed_qkv,
@@ -201,7 +203,8 @@ def split_l2norm_qkv_gates(
         head_v_dim=head_v_dim,
         block_t=block_t,
         block_k=triton.next_power_of_2(max(head_k_dim, head_v_dim)),
-        num_warps=4,
+        log_g=log_g,
+        num_warps=2,
         num_stages=3,
     )
     return q, k, v, g, beta
@@ -551,11 +554,11 @@ def _packed_gdn_decode_kernel(
     states,
     state_indices,
     output_indices,
-    stride_qkv,
-    stride_a,
-    stride_b,
-    stride_state,
-    stride_indices,
+    stride_qkv: tl.constexpr,
+    stride_a: tl.constexpr,
+    stride_b: tl.constexpr,
+    stride_state: tl.constexpr,
+    stride_indices: tl.constexpr,
     scale,
     num_k_heads: tl.constexpr,
     num_v_heads: tl.constexpr,
@@ -636,7 +639,12 @@ def _packed_gdn_decode_kernel(
         if output_indices is not None:
             write_slot = tl.load(output_indices + token).to(tl.int64)
             state_ptr = states + write_slot * stride_state + state_offsets
-        tl.store(state_ptr, state, mask=state_mask)
+        # Verification writes several large snapshots; only the accepted one
+        # will be read again. Evict these streaming writes before model weights.
+        tl.store(
+            state_ptr, state, mask=state_mask,
+            cache_modifier=".cs" if steps > 1 and states.dtype.element_ty == tl.bfloat16 else "",
+        )
         # Match the state precision of consecutive single-token decode calls.
         state = state.to(states.dtype.element_ty).to(tl.float32)
 
@@ -662,7 +670,9 @@ def packed_gdn_decode(
         device=mixed_qkv.device,
     )
     block_k = triton.next_power_of_2(head_k_dim)
-    block_v = min(triton.next_power_of_2(head_v_dim), 32)
+    # Smaller tiles reduce register pressure for BF16 multi-token verification.
+    tile_v = 16 if steps > 1 and states.dtype == torch.bfloat16 else 32
+    block_v = min(triton.next_power_of_2(head_v_dim), tile_v)
     _packed_gdn_decode_kernel[(triton.cdiv(head_v_dim, block_v), batch * num_v_heads)](
         mixed_qkv,
         a,
@@ -693,7 +703,7 @@ def packed_gdn_decode(
 
 
 @triton.jit
-def _packed_gdn_prefill_kernel(
+def _packed_gdn_prefill_reference_kernel(
     q,
     k,
     v,
@@ -753,7 +763,7 @@ def _packed_gdn_prefill_kernel(
     tl.store(state_ptr, state, mask=sm)
 
 
-def packed_gdn_prefill(
+def packed_gdn_prefill_reference(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -763,13 +773,17 @@ def packed_gdn_prefill(
     state_indices: torch.Tensor,
     cu_seqlens: torch.Tensor,
 ) -> torch.Tensor:
+    """Serial FP32 recurrence for accuracy checks; g contains decay factors.
+
+    Pass FP32 states to retain the reference's unrounded final state.
+    """
     num_k_heads, head_k_dim = q.shape[-2:]
     num_v_heads, head_v_dim = v.shape[-2:]
     output = torch.empty_like(v)
     block_k = triton.next_power_of_2(head_k_dim)
     block_v = min(triton.next_power_of_2(head_v_dim), 32)
     grid = (triton.cdiv(head_v_dim, block_v), state_indices.shape[0] * num_v_heads)
-    _packed_gdn_prefill_kernel[grid](
+    _packed_gdn_prefill_reference_kernel[grid](
         q,
         k,
         v,
@@ -791,6 +805,33 @@ def packed_gdn_prefill(
         num_stages=3,
     )
     return output
+
+
+def packed_gdn_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    log_g: torch.Tensor,
+    beta: torch.Tensor,
+    states: torch.Tensor,
+    state_indices: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+) -> torch.Tensor:
+    """FLA chunked prefill from zero state; gates are natural logarithms.
+
+    Intermediates and the state pool both use V-first layout.
+    cu_seqlens must be immutable for the forward; FLA caches its chunk indices.
+    """
+    from fla.ops.gated_delta_rule.chunk import chunk_gated_delta_rule_fwd
+
+    _, output, _, final_state, _, _ = chunk_gated_delta_rule_fwd(
+        q=q.unsqueeze(0), k=k.unsqueeze(0), v=v.unsqueeze(0),
+        g=log_g.unsqueeze(0), beta=beta.unsqueeze(0), scale=q.shape[-1] ** -0.5,
+        initial_state=None, output_final_state=True,
+        state_v_first=True, cu_seqlens=cu_seqlens,
+    )
+    scatter_recurrent_state(final_state, states, state_indices)
+    return output.squeeze(0)
 
 
 class GatedDeltaNetBackend:
@@ -833,6 +874,12 @@ class GatedDeltaNetBackend:
         head_v_dim: int,
         ssm_state_indices: torch.Tensor = None,
     ) -> torch.Tensor:
+        use_flashinfer = (
+            self._gdn_prefill is not None
+            and head_k_dim == head_v_dim == 128
+            and ssm_states.dtype in (torch.float32, torch.bfloat16)
+            and mixed_qkv.dtype in (torch.float16, torch.bfloat16)
+        )
         q, k, v, g, beta = split_l2norm_qkv_gates(
             mixed_qkv,
             a,
@@ -845,17 +892,12 @@ class GatedDeltaNetBackend:
             head_v_dim,
             conv_weight=conv_weight, conv_states=conv_states,
             query_start_loc=query_start_loc, state_indices=state_indices,
+            log_g=not use_flashinfer,
         )
         if ssm_state_indices is not None:
             state_indices = ssm_state_indices
 
-        # The FlashInfer CP prefill API uses 128x128 FP32 states.
-        if (
-            self._gdn_prefill is None
-            or head_k_dim != 128 or head_v_dim != 128
-            or ssm_states.dtype != torch.float32
-            or q.dtype not in (torch.float16, torch.bfloat16)
-        ):
+        if not use_flashinfer:
             return packed_gdn_prefill(
                 q,
                 k,
@@ -864,13 +906,15 @@ class GatedDeltaNetBackend:
                 beta,
                 ssm_states,
                 state_indices,
-                query_start_loc,
+                query_start_loc_i64,
             )
 
         # SFLLM has no prefix cache or chunked prefill, so EXTEND starts from
         # zero state.  Only the final state is materialized for later decode.
-        output_state = ssm_states.new_empty(
+        # CP accumulates in FP32; the final scatter rounds to the cache dtype.
+        output_state = torch.empty(
             (state_indices.shape[0], *ssm_states.shape[1:]),
+            dtype=torch.float32, device=ssm_states.device,
         )
         output, output_state = self._gdn_prefill(
             q=q,
@@ -891,7 +935,7 @@ class GatedDeltaNetBackend:
     def _decode_kernel(self, qkv, states, dt_bias, state_indices, output_indices):
         """Select an available implementation using tensor metadata only."""
         if (
-            self._gdn_decode is None or states.dtype != torch.float32
+            self._gdn_decode is None or states.dtype not in (torch.float32, torch.bfloat16)
             or qkv.dtype not in (torch.float16, torch.bfloat16)
             or dt_bias.dtype not in (torch.bfloat16, torch.float32)
         ):
@@ -900,12 +944,18 @@ class GatedDeltaNetBackend:
         if head_k_dim < 128 or head_v_dim < 128:
             return None
         if output_indices is None:
+            if states.dtype == torch.bfloat16:
+                if head_k_dim == head_v_dim == 128 and getattr(
+                    self._gdn_decode, "_GDN_DECODE_BF16_STATE_AVAILABLE", False
+                ):
+                    return self._gdn_decode.gated_delta_rule_decode_pretranspose
+                return None
             if (
                 getattr(self._gdn_decode, "run_pretranspose_decode", None) is not None
                 and head_v_dim % self._gdn_decode.TILE_V == 0
             ):
                 return self._gdn_decode.gated_delta_rule_decode_pretranspose
-        elif self._gdn_mtp is not None and output_indices.shape[1] >= 2:
+        elif states.dtype == torch.float32 and self._gdn_mtp is not None and output_indices.shape[1] >= 2:
             tile_v = self._gdn_decode.get_tile_v_mtp(
                 state_indices.shape[0], output_indices.shape[1],
                 num_v_heads=num_v_heads, v_dim=head_v_dim,

--- a/python/sfllm/kernels/gdn.py
+++ b/python/sfllm/kernels/gdn.py
@@ -929,7 +929,10 @@ class GatedDeltaNetBackend:
         if ssm_state_indices is not None:
             state_indices = ssm_state_indices
         steps = ssm_output_indices.shape[1] if ssm_output_indices is not None else 1
-        if self.decode_backend == "triton":
+        # BF16 verification has one implementation, independent of ordinary decode.
+        if self.decode_backend == "triton" or (
+            ssm_output_indices is not None and ssm_states.dtype == torch.bfloat16
+        ):
             core = packed_gdn_decode(
                 mixed_qkv=mixed_qkv,
                 a=a,

--- a/python/sfllm/kernels/gdn.py
+++ b/python/sfllm/kernels/gdn.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from inspect import signature
 from typing import Tuple
 
 import torch
@@ -11,39 +10,6 @@ import triton.language as tl
 from triton.experimental import gluon as tg
 from triton.experimental.gluon import language as gl
 import sf_kernel
-
-
-def _load_gdn_kernels(prefill_backend: str, decode_backend: str):
-    chunk_gated_delta_rule = None
-    gdn_decode = None
-    if prefill_backend == decode_backend == "triton":
-        return chunk_gated_delta_rule, gdn_decode
-    if torch.version.cuda is None:
-        return chunk_gated_delta_rule, gdn_decode
-    arch = torch.cuda.get_device_capability()[0]
-    if arch < 9:
-        return chunk_gated_delta_rule, gdn_decode
-    if prefill_backend == "flashinfer":
-        try:
-            from flashinfer import gdn_prefill
-
-            prefill = getattr(gdn_prefill, "chunk_gated_delta_rule", None)
-            if (
-                prefill is not None
-                and {"use_cp", "output_state"} <= signature(prefill).parameters.keys()
-                and getattr(gdn_prefill, f"cp_delta_rule_dsl_sm{arch}0", None) is not None
-                # FlashInfer's SM100 CP kernel requires CUDA 13.
-                and (arch != 10 or int(torch.version.cuda.split(".")[0]) >= 13)
-            ):
-                chunk_gated_delta_rule = prefill
-        except (ImportError, RuntimeError):
-            pass
-    if decode_backend == "flashinfer":
-        try:
-            from flashinfer import gdn_decode
-        except (ImportError, RuntimeError):
-            pass
-    return chunk_gated_delta_rule, gdn_decode
 
 
 @tg.jit(
@@ -843,16 +809,14 @@ class GatedDeltaNetBackend:
             raise ValueError("GDN backends must be one of: flashinfer, triton")
         self.prefill_backend = prefill_backend
         self.decode_backend = decode_backend
-        (
-            self._gdn_prefill,
-            self._gdn_decode,
-        ) = _load_gdn_kernels(prefill_backend, decode_backend)
-        self._gdn_mtp = getattr(self._gdn_decode, "gated_delta_rule_mtp", None)
-        if self._gdn_mtp is not None and (
-            getattr(self._gdn_decode, "get_tile_v_mtp", None) is None
-            or "ssm_state_indices" not in signature(self._gdn_mtp).parameters
-        ):
-            self._gdn_mtp = None
+        if prefill_backend == "flashinfer":
+            from flashinfer.gdn_prefill import chunk_gated_delta_rule
+
+            self._gdn_prefill = chunk_gated_delta_rule
+        if decode_backend == "flashinfer":
+            from flashinfer import gdn_decode
+
+            self._gdn_decode = gdn_decode
 
     def prefill(
         self,
@@ -874,12 +838,13 @@ class GatedDeltaNetBackend:
         head_v_dim: int,
         ssm_state_indices: torch.Tensor = None,
     ) -> torch.Tensor:
-        use_flashinfer = (
-            self._gdn_prefill is not None
-            and head_k_dim == head_v_dim == 128
+        use_flashinfer = self.prefill_backend == "flashinfer"
+        if use_flashinfer and not (
+            head_k_dim == head_v_dim == 128
             and ssm_states.dtype in (torch.float32, torch.bfloat16)
             and mixed_qkv.dtype in (torch.float16, torch.bfloat16)
-        )
+        ):
+            raise ValueError("FlashInfer GDN prefill requires K=V=128, FP16/BF16 inputs and FP32/BF16 states.")
         q, k, v, g, beta = split_l2norm_qkv_gates(
             mixed_qkv,
             a,
@@ -932,38 +897,6 @@ class GatedDeltaNetBackend:
         scatter_recurrent_state(output_state, ssm_states, state_indices)
         return output
 
-    def _decode_kernel(self, qkv, states, dt_bias, state_indices, output_indices):
-        """Select an available implementation using tensor metadata only."""
-        if (
-            self._gdn_decode is None or states.dtype not in (torch.float32, torch.bfloat16)
-            or qkv.dtype not in (torch.float16, torch.bfloat16)
-            or dt_bias.dtype not in (torch.bfloat16, torch.float32)
-        ):
-            return None
-        num_v_heads, head_v_dim, head_k_dim = states.shape[-3:]
-        if head_k_dim < 128 or head_v_dim < 128:
-            return None
-        if output_indices is None:
-            if states.dtype == torch.bfloat16:
-                if head_k_dim == head_v_dim == 128 and getattr(
-                    self._gdn_decode, "_GDN_DECODE_BF16_STATE_AVAILABLE", False
-                ):
-                    return self._gdn_decode.gated_delta_rule_decode_pretranspose
-                return None
-            if (
-                getattr(self._gdn_decode, "run_pretranspose_decode", None) is not None
-                and head_v_dim % self._gdn_decode.TILE_V == 0
-            ):
-                return self._gdn_decode.gated_delta_rule_decode_pretranspose
-        elif states.dtype == torch.float32 and self._gdn_mtp is not None and output_indices.shape[1] >= 2:
-            tile_v = self._gdn_decode.get_tile_v_mtp(
-                state_indices.shape[0], output_indices.shape[1],
-                num_v_heads=num_v_heads, v_dim=head_v_dim,
-            )
-            if head_v_dim % tile_v == 0:
-                return self._gdn_mtp
-        return None
-
     def decode(
         self,
         projected_qkvz: torch.Tensor,
@@ -996,10 +929,7 @@ class GatedDeltaNetBackend:
         if ssm_state_indices is not None:
             state_indices = ssm_state_indices
         steps = ssm_output_indices.shape[1] if ssm_output_indices is not None else 1
-        recurrent = self._decode_kernel(
-            mixed_qkv, ssm_states, dt_bias, state_indices, ssm_output_indices
-        )
-        if recurrent is None:
+        if self.decode_backend == "triton":
             core = packed_gdn_decode(
                 mixed_qkv=mixed_qkv,
                 a=a,
@@ -1012,6 +942,11 @@ class GatedDeltaNetBackend:
                 ssm_output_indices=ssm_output_indices,
             )
         else:
+            recurrent = (
+                self._gdn_decode.gated_delta_rule_mtp
+                if ssm_output_indices is not None
+                else self._gdn_decode.gated_delta_rule_decode_pretranspose
+            )
             state_options = (
                 dict(ssm_state_indices=ssm_output_indices, disable_state_update=False)
                 if ssm_output_indices is not None else dict(state=None)

--- a/python/sfllm/models/qwen3_5.py
+++ b/python/sfllm/models/qwen3_5.py
@@ -466,7 +466,8 @@ class Qwen3_5Model(nn.Module):
                 config.linear_value_head_dim,
                 config.linear_key_head_dim,
                 dtype={"float32": torch.float32, "bfloat16": torch.bfloat16}[
-                    vars(config).get("mamba_ssm_dtype", "float32")
+                    server_args.mamba_ssm_dtype
+                    or vars(config).get("mamba_ssm_dtype", "float32")
                 ],
             ),
             persistent=False,

--- a/python/sfllm/server_args.py
+++ b/python/sfllm/server_args.py
@@ -24,6 +24,7 @@ class ServerArgs:
     linear_attn_backend: Literal["triton", "flashinfer"] = "flashinfer"
     linear_attn_prefill_backend: Optional[Literal["triton", "flashinfer"]] = None
     linear_attn_decode_backend: Optional[Literal["triton", "flashinfer"]] = None
+    mamba_ssm_dtype: Optional[Literal["float32", "bfloat16"]] = None
     # speculative decoding
     speculative_algorithm: Optional[str] = None
     speculative_draft_model_path: Optional[str] = None
@@ -140,6 +141,12 @@ class ServerArgs:
             default=ServerArgs.linear_attn_decode_backend,
             choices=["triton", "flashinfer"],
             help="GDN decode backend; inherits --linear-attn-backend when unset.",
+        )
+        parser.add_argument(
+            "--mamba-ssm-dtype",
+            choices=["float32", "bfloat16"],
+            default=ServerArgs.mamba_ssm_dtype,
+            help="Recurrent SSM state dtype; defaults to the model config or float32.",
         )
         parser.add_argument(
             "--tokenizer-mode",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ aiohttp>=3.8.4
 safetensors>=0.4.0
 # Qwen3.5 Gated DeltaNet runtime kernels.
 flashinfer-python>=0.6.14
+fla-core==0.5.2
 sglang-kernel>=0.4.6


### PR DESCRIPTION
Replace serial Triton GDN prefill with FLA chunked prefill, retain the serial reference, optimize BF16 verify, and enable FlashInfer BF16 prefill/decode plus `--mamba-ssm-dtype`. Ordinary prefill/decode honor the requested backend; BF16 verify uses Triton.

Validated variable-length batches, both backends/SSM dtypes, and CUDA graphs. BF16 verify remains bitexact for B=10/20/22/30, block=4/5/6. FLA prefill is not bitexact to serial FP32 (output relative L2 ≈0.4%); SSM storage follows the requested dtype.

**Polaris500:** H100 NVL, Qwen3.5 FP8 + DFlash2, FA3, block 5, concurrency 22, greedy, max output 1000. Base `2c47690` → PR `d41aa5d`; every run 500/0.

| Backend | SSM | Runs per revision | Base tok/s | PR tok/s | Throughput Δ |
|---|---|---:|---:|---:|---:|
| Triton | FP32 | 1 | 1285.21 | 3270.31 | +154.46% |
| Triton | BF16 | 1 | 1330.01 | 3461.08 | +160.23% |
| FlashInfer | FP32 | 3, mean | 3392.44 | 3399.73 | +0.21% |
| FlashInfer | BF16 | 1 | 1335.69 | 3589.36 | +168.73% |

FlashInfer/FP32 is essentially unchanged: three pair deltas **−0.30%, +1.07%, −0.13%**; median **−0.12%**. Base FlashInfer/BF16 prefill falls back to serial Triton; PR uses native FlashInfer.

<details>
<summary>Kernel timings and complete serving results</summary>

Kernel timings: main → PR, μs per GDN layer; H100 NVL, BF16 activations, Hq/Hk=16, Hv=32, K/V=128. Five warmed alternating nsys samples, including convolution/preprocessing and state writeback; GPU kernel time only. Decode graphs use eight independent layer states.

| Requested backend | SSM | Prefill: 22 requests / 7,404 tokens | Prefill: 22 requests / 30,731 tokens |
|---|---|---:|---:|
| triton | float32 | 3392.50 → 953.86 | 18322.84 → 3528.24 |
| triton | bfloat16 | 3327.78 → 947.64 | 17728.23 → 3525.98 |
| flashinfer | float32 | 687.46 → 687.05 | 2215.12 → 2214.61 |
| flashinfer | bfloat16 | 3366.72 → 679.65 | 17892.65 → 2210.37 |

| Requested backend | SSM | Decode: B22 / 1 step | Verify: B22 / 5 steps |
|---|---|---:|---:|
| triton | float32 | 35.82 → 34.99 | 105.80 → 105.88 |
| triton | bfloat16 | 21.59 → 22.10 | 69.82 → 61.45 |
| flashinfer | float32 | 34.70 → 34.81 | 104.82 → 104.56 |
| flashinfer | bfloat16 | 21.52 → 21.25 | Same fixed Triton path above |

BF16 verify uses Triton for both backend settings. FlashInfer BF16 decode is not uniformly faster: B22 with graph B24 is 21.69 → 21.80 μs; graph B32 is 21.87 → 25.13 μs.

Initial Polaris500 runs, same prompts, seed 42, 22-request warmup and cache/counter reset:

| Requested backend | SSM | Revision | Actual prefill | QPS | p95 E2E (s) | Avg output | Accept len | TPOT (ms) | p95 TTFT (ms) | Output tok/s | Output throughput Δ | Wall (s) |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| triton | float32 | base | serial Triton | 2.3650 | 13.3419 | 543.43 | 3.0269 | 15.993 | 1209.847 | 1285.21 | — | 211.42 |
| triton | float32 | pr | FLA (Triton) | 6.0447 | 5.0238 | 541.02 | 3.0361 | 6.362 | 280.768 | 3270.31 | +154.46% | 82.72 |
| triton | bfloat16 | base | serial Triton | 2.4305 | 13.1081 | 547.21 | 3.0255 | 15.422 | 1172.297 | 1330.01 | — | 205.72 |
| triton | bfloat16 | pr | FLA (Triton) | 6.3451 | 4.9447 | 545.47 | 3.0386 | 5.998 | 307.810 | 3461.08 | +160.23% | 78.80 |
| flashinfer | float32 | base | FlashInfer | 6.3183 | 4.8990 | 537.97 | 3.0296 | 6.120 | 331.165 | 3399.03 | — | 79.14 |
| flashinfer | float32 | pr | FlashInfer | 6.2811 | 4.8720 | 539.54 | 3.0396 | 6.151 | 274.360 | 3388.90 | -0.30% | 79.60 |
| flashinfer | bfloat16 | base | serial Triton | 2.4440 | 13.1153 | 546.52 | 3.0239 | 15.330 | 1242.802 | 1335.69 | — | 204.58 |
| flashinfer | bfloat16 | pr | FlashInfer | 6.5733 | 4.8624 | 546.05 | 3.0326 | 5.788 | 261.202 | 3589.36 | +168.73% | 76.07 |

FlashInfer/FP32 repeats, same settings:

| Trial | Base tok/s | PR tok/s | Throughput Δ | Base / PR accept len |
|---|---:|---:|---:|---:|
| 1 | 3399.03 | 3388.90 | −0.30% | 3.0296 / 3.0396 |
| 2 | 3392.86 | 3429.31 | +1.07% | 3.0383 / 3.0338 |
| 3 | 3385.45 | 3380.98 | −0.13% | 3.0413 / 3.0368 |

Mean: 3392.44 → 3399.73 tok/s (+0.21%); median: 3392.86 → 3388.90 (−0.12%).

</details>

A 30-request repro traced an output divergence to existing FlashInfer CP prefill chunk selection (4096 vs 3584); identical inputs with the same chunk length produce bitexact GDN output. This was diagnostic only; CP behavior is unchanged by this PR.

Commands, logs and validation: `/tmp/sfllm-gdn-pr-4gwejic2/` (`polaris500/`, `polaris500-repeat-fp32/`, `trace30/`).
