### PR TITLE
feat: support DSpark speculative decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ For a compatible Qwen3.5 DFlash2 draft, add:
 The draft token count is configurable (2 to the checkpoint block size); omit it
 to use the checkpoint default. The selector top-k stays as configured in the checkpoint.
 
+For a Qwen3 DSpark draft (`DSparkDraftModel` or `Qwen3DSparkModel`), use:
+
+```bash
+  --attention-backend fa3 \
+  --speculative-algorithm dspark \
+  --speculative-draft-model-path /path/to/dspark-checkpoint \
+  --speculative-num-draft-tokens 6
+```
+
+This example uses 6 draft queries (anchor + 5 masks) to propose 5 tokens from the mask
+positions; the target verifies 6 tokens including the anchor. Omit the token count to use the checkpoint's gamma
+plus one (`dspark_block_size` takes precedence over `block_size`). Qwen3 and Qwen3.5
+targets, vanilla/gated/RNN Markov heads, and mixed sliding/full draft attention are
+supported. Decoding is fixed-width and greedy; confidence-head weights are unused.
+For vanilla Markov heads, `--speculative-dspark-topk 16` restricts draft proposals
+to the top 16 unary candidates and computes their transitions together. This can
+change draft acceptance; every emitted token is still verified by the target.
+The default, `-1`, runs original DSpark and scores the full vocabulary.
 For Qwen3.5, `--mamba-ssm-dtype bfloat16` explicitly selects BF16 recurrent
 states. The default uses the model config's SSM dtype, or FP32 if unspecified.
 GDN prefill and ordinary decode use their selected backends. BF16 speculative
@@ -164,7 +182,7 @@ curl http://localhost:8081/health
 | `--max-context-length` | Maximum context length | 4096 |
 | `--cuda-graph-max-bs` | Max CUDA graph batch size | 32 |
 | `--disable-cuda-graph` | Disable CUDA graphs | False |
-| `--speculative-algorithm` | Speculative decoding algorithm (`eagle3` or `dflash2`) | None |
+| `--speculative-algorithm` | Speculative decoding algorithm (`eagle3`, `dflash2`, or `dspark`) | None |
 | `--speculative-draft-model-path` | Path to the speculative draft model | None |
 | `--speculative-num-steps` | Number of speculative steps | 4 |
 | `--disable-overlap` | Disable overlap scheduling | False |

--- a/README_CN.md
+++ b/README_CN.md
@@ -110,7 +110,7 @@ curl http://localhost:8081/health
 | `--max-context-length` | 最大上下文长度 | 4096 |
 | `--cuda-graph-max-bs` | CUDA图最大批处理大小 | 32 |
 | `--disable-cuda-graph` | 禁用CUDA图 | False |
-| `--speculative-algorithm` | 投机解码算法 (`eagle3` 或 `dflash2`) | None |
+| `--speculative-algorithm` | 投机解码算法 (`eagle3`、`dflash2` 或 `dspark`) | None |
 | `--speculative-draft-model-path` | 投机解码草稿模型路径 | None |
 | `--speculative-num-steps` | 投机解码步数 | 4 |
 | `--disable-overlap` | 禁用重叠调度 | False |

--- a/python/sfllm/engine/inference_engine.py
+++ b/python/sfllm/engine/inference_engine.py
@@ -13,6 +13,7 @@ from typing import Dict, Any, List, Tuple, Generator
 
 from sfllm.engine.model_worker import ModelWorker
 from sfllm.spec_decoding.dflash2_worker import DFlash2Worker
+from sfllm.spec_decoding.dspark_worker import DSparkWorker
 from sfllm.spec_decoding.eagle_worker import EagleWorker
 from sfllm.engine.scheduler import Scheduler
 from sfllm.engine.sampling_params import SamplingParams
@@ -40,6 +41,8 @@ class InferenceEngine:
             self.model_worker = EagleWorker(server_args)
         elif server_args.speculative_algorithm == "dflash2":
             self.model_worker = DFlash2Worker(server_args)
+        elif server_args.speculative_algorithm == "dspark":
+            self.model_worker = DSparkWorker(server_args)
         else:
             self.model_worker = ModelWorker(server_args)
         self.server_args = server_args

--- a/python/sfllm/models/dflash2.py
+++ b/python/sfllm/models/dflash2.py
@@ -21,6 +21,7 @@ except ImportError:
     _flashinfer_top_k = None
 
 from sfllm.engine.forward_params import ForwardBatch
+from sfllm.kernels.dflash2 import dflash2_selector_greedy_walk
 from sfllm.layers.layernorm import RMSNorm
 from sfllm.model_loader.weight_utils import default_weight_loader
 from sfllm.models.qwen3 import Qwen3Attention, Qwen3MLP
@@ -234,11 +235,13 @@ class DFlash2GroupedConv(nn.Module):
 
 
 class DFlash2DecoderLayer(nn.Module):
-    def __init__(self, config, layer_id: int, quant_config=None) -> None:
+    def __init__(
+        self, config, layer_id: int, draft_config, attention_cls, quant_config=None
+    ) -> None:
         super().__init__()
         hidden_size = int(config.hidden_size)
         self.input_layernorm = RMSNorm(hidden_size, eps=float(config.rms_norm_eps))
-        self.self_attn = DFlash2Attention(
+        self.self_attn = attention_cls(
             config,
             layer_id,
             quant_config=quant_config,
@@ -254,14 +257,16 @@ class DFlash2DecoderLayer(nn.Module):
             quant_config=quant_config,
             prefix=f"layers.{layer_id}.mlp",
         )
-        conv_args = (
-            hidden_size,
-            int(config.dflash_config["block_size"]),
-            int(config.dflash_config["conv_kernel_size"]),
-            int(config.dflash_config["conv_group_size"]),
-        )
-        self.attention_conv = DFlash2GroupedConv(*conv_args)
-        self.mlp_conv = DFlash2GroupedConv(*conv_args)
+        self.attention_conv = self.mlp_conv = None
+        if draft_config.conv_kernel_size:
+            conv_args = (
+                hidden_size,
+                draft_config.block_size,
+                draft_config.conv_kernel_size,
+                draft_config.conv_group_size,
+            )
+            self.attention_conv = DFlash2GroupedConv(*conv_args)
+            self.mlp_conv = DFlash2GroupedConv(*conv_args)
 
     def forward(
         self,
@@ -276,16 +281,20 @@ class DFlash2DecoderLayer(nn.Module):
         else:
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
 
-        hidden_states, attention_kernel = self.attention_conv.prepare(hidden_states)
+        if self.attention_conv is not None:
+            hidden_states, attention_kernel = self.attention_conv.prepare(hidden_states)
         hidden_states = self.self_attn(positions, hidden_states, forward_batch)
-        hidden_states = self.attention_conv.finish(hidden_states, attention_kernel)
+        if self.attention_conv is not None:
+            hidden_states = self.attention_conv.finish(hidden_states, attention_kernel)
 
         hidden_states, residual = self.post_attention_layernorm(
             hidden_states, residual
         )
-        hidden_states, mlp_kernel = self.mlp_conv.prepare(hidden_states)
+        if self.mlp_conv is not None:
+            hidden_states, mlp_kernel = self.mlp_conv.prepare(hidden_states)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = self.mlp_conv.finish(hidden_states, mlp_kernel)
+        if self.mlp_conv is not None:
+            hidden_states = self.mlp_conv.finish(hidden_states, mlp_kernel)
         return hidden_states, residual
 
 
@@ -327,23 +336,25 @@ class DFlash2CandidateSelector(nn.Module):
 class DFlash2DraftModel(nn.Module):
     """Qwen3 DFlash2 backbone and low-rank path selector."""
 
+    config_cls = DFlash2Config
+    attention_cls = DFlash2Attention
+
     def __init__(self, config, quant_config=None, prefix: str = "") -> None:
         super().__init__()
         del prefix
         self.config = config
-        self.dflash_config = DFlash2Config.from_hf_config(config)
-        window = (
-            int(config.sliding_window) - 1
-            if "sliding_attention" in config.layer_types else -1
-        )
+        self.dflash_config = self.config_cls.from_hf_config(config)
+        window = int(config.sliding_window) - 1 if "sliding_attention" in config.layer_types else -1
         config.window_size = (
-            window,
-            0 if window >= 0 and DFlash2Attention.attention_is_causal(config, True) else window,
+            window, 0 if window >= 0 and self.attention_cls.attention_is_causal(config, True) else window
         )
         hidden_size = int(config.hidden_size)
         self.layers = nn.ModuleList(
             [
-                DFlash2DecoderLayer(config, layer_id, quant_config=quant_config)
+                DFlash2DecoderLayer(
+                    config, layer_id, self.dflash_config, self.attention_cls,
+                    quant_config=quant_config,
+                )
                 for layer_id in range(int(config.num_hidden_layers))
             ]
         )
@@ -355,13 +366,16 @@ class DFlash2DraftModel(nn.Module):
         )
         self.speculative_hidden_size = self.fc.out_features
         self.hidden_norm = RMSNorm(hidden_size, eps=float(config.rms_norm_eps))
+        self._init_proposal_head()
+        self.register_buffer("_flat_kv_weight_t", None, persistent=False)
+
+    def _init_proposal_head(self) -> None:
         self.candidate_selector = DFlash2CandidateSelector(
-            hidden_size,
-            int(config.vocab_size),
+            int(self.config.hidden_size),
+            int(self.config.vocab_size),
             self.dflash_config.selector_rank,
             self.dflash_config.selector_top_k,
         )
-        self.register_buffer("_flat_kv_weight_t", None, persistent=False)
 
     def forward(
         self,
@@ -385,23 +399,39 @@ class DFlash2DraftModel(nn.Module):
         return hidden_states
 
     def compute_candidates(
-        self, hidden_states: torch.Tensor, target_head_weight: torch.Tensor
+        self, hidden_states: torch.Tensor, target_head_weight: torch.Tensor,
+        top_k: Optional[int] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if top_k is None:
+            top_k = self.dflash_config.selector_top_k
+        shape = (*hidden_states.shape[:-1], top_k)
+        hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
         logits = torch.matmul(
             hidden_states.to(target_head_weight.dtype), target_head_weight.T
         )
         if _flashinfer_top_k is None:
             values, ids = torch.topk(
-                logits, self.dflash_config.selector_top_k, dim=-1, sorted=True
+                logits, top_k, dim=-1, sorted=True
             )
         else:
             values, ids = _flashinfer_top_k(
                 logits,
-                self.dflash_config.selector_top_k,
+                top_k,
                 sorted=True,
                 deterministic=True,
             )
-        return ids.to(torch.int64), values.float()
+        return ids.to(torch.int64).view(shape), values.float().view(shape)
+
+    def sample_proposals(self, hidden_states, target_head_weight, anchor_tokens, out):
+        candidate_ids, unary_logits = self.compute_candidates(
+            hidden_states, target_head_weight
+        )
+        pairwise = self.candidate_selector.compute_pairwise_scores(
+            candidate_ids=candidate_ids,
+            hidden_states=hidden_states,
+            anchor_token_ids=anchor_tokens,
+        )
+        dflash2_selector_greedy_walk(candidate_ids, unary_logits, pairwise, out)
 
     def project_target_hidden(self, target_hidden: torch.Tensor) -> torch.Tensor:
         if target_hidden.ndim != 2 or target_hidden.shape[1] != self.fc.in_features:
@@ -481,7 +511,7 @@ class DFlash2DraftModel(nn.Module):
             if name in ignored:
                 continue
             for packed_name, checkpoint_name, shard_id in stacked_params:
-                if f".{checkpoint_name}." not in f".{name}":
+                if not name.startswith("layers.") or f".{checkpoint_name}." not in name:
                     continue
                 mapped_name = name.replace(checkpoint_name, packed_name)
                 if mapped_name not in params:

--- a/python/sfllm/models/dspark.py
+++ b/python/sfllm/models/dspark.py
@@ -1,0 +1,180 @@
+"""Qwen3 DSpark draft: shared target-KV backbone with a Markov proposal head."""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+from torch import nn
+
+from sfllm.kernels.dflash2 import dflash2_selector_greedy_walk
+from sfllm.kernels.sampling import logits_argmax
+from sfllm.models.dflash2 import DFlash2Attention, DFlash2DraftModel
+
+
+@dataclass(frozen=True)
+class DSparkConfig:
+    # Number of proposals, excluding the anchor in the target verify block.
+    block_size: int
+    mask_token_id: int
+    target_layer_ids: Tuple[int, ...]
+    markov_rank: int
+    markov_head_type: str
+    conv_kernel_size: int = 0
+    conv_group_size: int = 0
+
+    @classmethod
+    def from_hf_config(cls, config):
+        raw = config.to_dict() if hasattr(config, "to_dict") else dict(config)
+        fields = {**raw, **raw.get("dflash_config", {}), **raw.get("dspark_config", {})}
+        for key in ("block_size", "markov_rank", "markov_head_type", "target_layer_ids"):
+            if raw.get(f"dspark_{key}") is not None:
+                fields[key] = raw[f"dspark_{key}"]
+        if raw.get("dspark_noise_token_id") is not None:
+            fields["mask_token_id"] = raw["dspark_noise_token_id"]
+        try:
+            parsed = cls(
+                block_size=int(fields["block_size"]),
+                mask_token_id=int(fields["mask_token_id"]),
+                target_layer_ids=tuple(int(x) for x in fields["target_layer_ids"]),
+                markov_rank=int(fields["markov_rank"]),
+                markov_head_type=str(fields["markov_head_type"]).lower(),
+                conv_kernel_size=int(fields.get("conv_kernel_size", 0)),
+                conv_group_size=int(fields.get("conv_group_size", 0)),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError("Invalid DSpark checkpoint config.") from exc
+        if raw.get("model_type") != "qwen3" or raw.get("attention_bias", False):
+            raise ValueError("DSpark requires a Qwen3 draft with attention_bias=false.")
+        if parsed.block_size < 1 or parsed.markov_rank < 1:
+            raise ValueError("DSpark block_size and markov_rank must be positive.")
+        if parsed.markov_head_type not in ("vanilla", "gated", "rnn"):
+            raise ValueError(f"Unsupported DSpark Markov head: {parsed.markov_head_type}.")
+        if not 0 <= parsed.mask_token_id < int(raw["vocab_size"]):
+            raise ValueError("DSpark mask_token_id is outside the vocabulary.")
+        ids = parsed.target_layer_ids
+        if not ids or min(ids) < 0 or tuple(sorted(set(ids))) != ids:
+            raise ValueError("DSpark target_layer_ids must be non-negative, unique and sorted.")
+        taps, group = parsed.conv_kernel_size, parsed.conv_group_size
+        if taps < 0 or group < 0 or bool(taps) != bool(group):
+            raise ValueError("DSpark convolution sizes must both be positive or both zero.")
+        if group and int(raw["hidden_size"]) % group:
+            raise ValueError("DSpark conv_group_size must divide hidden_size.")
+        layers = raw.get("layer_types")
+        if (
+            not layers or len(layers) != int(raw["num_hidden_layers"])
+            or any(t not in ("full_attention", "sliding_attention") for t in layers)
+        ):
+            raise ValueError("DSpark requires one full/sliding attention type per draft layer.")
+        if "sliding_attention" in layers and int(raw.get("sliding_window") or 0) <= 0:
+            raise ValueError("DSpark sliding attention requires a positive window.")
+        return parsed
+
+
+class DSparkAttention(DFlash2Attention):
+    @staticmethod
+    def attention_is_causal(config, sliding):
+        return getattr(config, "is_causal", sliding)
+
+
+class DSparkMarkovHead(nn.Module):
+    def __init__(self, hidden_size, vocab_size, rank, head_type):
+        super().__init__()
+        self.head_type = head_type
+        self.markov_w1 = nn.Embedding(vocab_size, rank)
+        self.markov_w2 = nn.Linear(rank, vocab_size, bias=False)
+        if head_type == "gated":
+            self.gate_proj = nn.Linear(hidden_size + rank, rank)
+        elif head_type == "rnn":
+            self.joint_proj = nn.Linear(hidden_size + 2 * rank, 3 * rank)
+        elif head_type != "vanilla":
+            raise ValueError(f"Unsupported DSpark Markov head: {head_type}.")
+
+    def sample_candidates(self, candidate_ids, unary_logits, anchor_tokens, out):
+        """Build all top-k Markov edges together, then walk the small lattice."""
+        if self.head_type != "vanilla":
+            raise ValueError("DSpark top-k proposals require a vanilla Markov head.")
+        top_k = candidate_ids.shape[-1]
+        predecessors = torch.cat([
+            anchor_tokens[:, None, None].expand(-1, 1, top_k),
+            candidate_ids[:, :-1],
+        ], dim=1)
+        predecessor_latent = self.markov_w1(predecessors)
+        successor_latent = self.markov_w2.weight[candidate_ids]
+        transitions = torch.einsum(
+            "blpr,blcr->blpc", predecessor_latent, successor_latent
+        )
+        dflash2_selector_greedy_walk(candidate_ids, unary_logits, transitions, out)
+
+    def sample(self, base_logits, hidden_states, anchor_tokens, out):
+        previous = anchor_tokens
+        state = None
+        for step in range(base_logits.shape[1]):
+            latent = self.markov_w1(previous)
+            if self.head_type == "gated":
+                gate = torch.sigmoid(self.gate_proj(torch.cat(
+                    [hidden_states[:, step], latent], dim=-1
+                )))
+                latent = gate * latent
+            elif self.head_type == "rnn":
+                if state is None:
+                    state = torch.zeros_like(latent)
+                gate, candidate, output = self.joint_proj(torch.cat(
+                    [state, latent, hidden_states[:, step]], dim=-1
+                )).chunk(3, dim=-1)
+                gate = torch.sigmoid(gate)
+                state = gate * state + (1 - gate) * torch.tanh(candidate)
+                latent = torch.tanh(output)
+            # Preserve checkpoint dtype rounding in both projection and addition.
+            previous = logits_argmax(
+                base_logits[:, step], self.markov_w2(latent), out=out[:, step]
+            )
+
+
+class DSparkDraftModel(DFlash2DraftModel):
+    config_cls = DSparkConfig
+    attention_cls = DSparkAttention
+
+    def _init_proposal_head(self):
+        self.proposal_top_k = -1
+        self.markov_head = DSparkMarkovHead(
+            int(self.config.hidden_size), int(self.config.vocab_size),
+            self.dflash_config.markov_rank, self.dflash_config.markov_head_type,
+        )
+
+    def sample_proposals(self, hidden_states, target_head_weight, anchor_tokens, out):
+        if self.proposal_top_k > 0:
+            ids, unary = self.compute_candidates(
+                hidden_states, target_head_weight,
+                top_k=self.proposal_top_k,
+            )
+            self.markov_head.sample_candidates(
+                ids, unary.to(target_head_weight.dtype), anchor_tokens, out
+            )
+            return
+        # Dropping the anchor leaves gaps between requests. Flatten explicitly
+        # so matmul uses one GEMM instead of rereading the head for each request.
+        batch, slots, hidden_size = hidden_states.shape
+        flat_hidden = hidden_states.reshape(-1, hidden_size).to(target_head_weight.dtype)
+        logits = torch.matmul(flat_hidden, target_head_weight.T).view(batch, slots, -1)
+        self.markov_head.sample(logits, hidden_states, anchor_tokens, out)
+
+    def load_weights(self, weights):
+        def backbone_and_markov_weights():
+            for name, weight in weights:
+                name = name.removeprefix("model.")
+                # Fixed-width greedy decoding does not use the confidence planner.
+                if name in ("confidence_head.proj.weight", "confidence_head.proj.bias"):
+                    continue
+                name = {
+                    "encoder.fc.weight": "fc.weight",
+                    "encoder.output_norm_enc.weight": "hidden_norm.weight",
+                }.get(name, name)
+                yield name, weight
+        super().load_weights(backbone_and_markov_weights())
+
+
+class Qwen3DSparkModel(DSparkDraftModel):
+    pass
+
+
+EntryClass = [DSparkDraftModel, Qwen3DSparkModel]

--- a/python/sfllm/models/qwen3_5.py
+++ b/python/sfllm/models/qwen3_5.py
@@ -441,7 +441,7 @@ class Qwen3_5Model(nn.Module):
         max_state_rows = int(server_args.max_running_requests)
         spec_steps = (
             server_args.speculative_num_draft_tokens
-            if server_args.speculative_algorithm == "dflash2" else 0
+            if server_args.speculative_algorithm in ("dflash2", "dspark") else 0
         )
         conv_dim = (
             2 * config.linear_num_key_heads * config.linear_key_head_dim

--- a/python/sfllm/server_args.py
+++ b/python/sfllm/server_args.py
@@ -31,6 +31,7 @@ class ServerArgs:
     speculative_eagle_topk: int = 4
     speculative_num_steps: int = 4
     speculative_num_draft_tokens: Optional[int] = None
+    speculative_dspark_topk: int = -1
 
     #piecewise for prefill
     enable_piecewise_cuda_graph: bool = False
@@ -183,7 +184,7 @@ class ServerArgs:
             "--speculative-algorithm",
             type=str.lower,
             default=ServerArgs.speculative_algorithm,
-            choices=[None, "eagle3", "dflash2"],
+            choices=[None, "eagle3", "dflash2", "dspark"],
             help="The speculative decoding algorithm to use.",
         )
         parser.add_argument(
@@ -199,6 +200,12 @@ class ServerArgs:
             help="The top-k value for Eagle speculative decoding.",
         )
         parser.add_argument(
+            "--speculative-dspark-topk",
+            type=int,
+            default=ServerArgs.speculative_dspark_topk,
+            help="Restrict vanilla DSpark proposals to unary top-k candidates; -1 uses original DSpark with the full vocabulary.",
+        )
+        parser.add_argument(
             "--speculative-num-steps",
             type=int,
             default=ServerArgs.speculative_num_steps,
@@ -208,7 +215,7 @@ class ServerArgs:
             "--speculative-num-draft-tokens",
             type=int,
             default=ServerArgs.speculative_num_draft_tokens,
-            help="Draft token count: defaults to 8 for Eagle, or the checkpoint block size for DFlash2.",
+            help="Verify token count: defaults to 8 for Eagle, checkpoint block_size for DFlash2, or gamma+1 for DSpark.",
         )
         parser.add_argument(
             "--enable-debug",
@@ -227,7 +234,7 @@ class ServerArgs:
         return cls(**{attr: getattr(args, attr) for attr in attrs})
 
     def __post_init__(self):
-        if self.speculative_num_draft_tokens is None and self.speculative_algorithm != "dflash2":
+        if self.speculative_num_draft_tokens is None and self.speculative_algorithm not in ("dflash2", "dspark"):
             self.speculative_num_draft_tokens = 8
         if self.max_running_requests is None:
             self.max_running_requests = self.cuda_graph_max_bs

--- a/python/sfllm/spec_decoding/dflash2_worker.py
+++ b/python/sfllm/spec_decoding/dflash2_worker.py
@@ -4,10 +4,7 @@ import torch
 
 from sfllm.engine.forward_params import ForwardBatch, ForwardMode
 from sfllm.engine.schedule_batch import BatchResult, ScheduleBatch
-from sfllm.kernels.dflash2 import (
-    dflash2_selector_greedy_walk,
-    prepare_dflash2_block,
-)
+from sfllm.kernels.dflash2 import prepare_dflash2_block
 from sfllm.models.dflash2 import DFlash2Config
 from sfllm.models.interfaces import HasBatchState
 from sfllm.model_loader.model_config import ModelConfig
@@ -22,13 +19,13 @@ def _validate_model_pair(
     dflash2_config: DFlash2Config,
 ) -> None:
     if getattr(target_config, "model_type", None) not in ("qwen3", "qwen3_5_text"):
-        raise ValueError("DFlash2 supports Qwen3 and Qwen3.5 targets.")
+        raise ValueError("Block drafts support Qwen3 and Qwen3.5 targets.")
     for name in ("hidden_size", "vocab_size"):
         draft_value = getattr(draft_config, name, None)
         target_value = getattr(target_config, name, None)
         if draft_value != target_value:
             raise ValueError(
-                "DFlash2 draft/target shape mismatch: "
+                "Draft/target shape mismatch: "
                 f"draft {name}={draft_value!r}, target {name}={target_value!r}."
             )
 
@@ -40,7 +37,7 @@ def _validate_model_pair(
     ]
     if invalid_layer_ids:
         raise ValueError(
-            "DFlash2 target_layer_ids are outside the target model: "
+            "Draft target_layer_ids are outside the target model: "
             f"{invalid_layer_ids}."
         )
 
@@ -48,31 +45,35 @@ def _validate_model_pair(
 class DFlash2Worker(SpeculativeWorker):
     """DFlash2 model logic on top of SFLLM's Eagle overlap contract."""
 
+    config_cls = DFlash2Config
+    checkpoint_verify_extra = 0
+
     def __init__(self, server_args: ServerArgs) -> None:
         if not server_args.speculative_draft_model_path:
-            raise ValueError("DFlash2 requires --speculative-draft-model-path.")
+            raise ValueError("Block drafts require --speculative-draft-model-path.")
         if server_args.quantization is not None:
             raise ValueError(
-                "DFlash2 reads target quantization from the checkpoint; omit --quantization."
+                "Block drafts read target quantization from the checkpoint; omit --quantization."
             )
 
         draft_config = ModelConfig(
             server_args.speculative_draft_model_path
         ).hf_config
-        checkpoint_config = DFlash2Config.from_hf_config(draft_config)
+        checkpoint_config = self.config_cls.from_hf_config(draft_config)
         if (
             "sliding_attention" in draft_config.layer_types
             and server_args.attention_backend != "fa3"
         ):
-            raise ValueError("DFlash2 sliding attention requires --attention-backend fa3.")
+            raise ValueError("Sliding draft attention requires --attention-backend fa3.")
 
-        # A DFlash block maps directly to the shared Eagle protocol width.
+        # DSpark config counts proposals; DFlash2 config includes the anchor.
+        max_block_size = checkpoint_config.block_size + self.checkpoint_verify_extra
         self.block_size = server_args.speculative_num_draft_tokens
         if self.block_size is None:
-            self.block_size = checkpoint_config.block_size
-        if not 2 <= self.block_size <= checkpoint_config.block_size:
+            self.block_size = max_block_size
+        if not 2 <= self.block_size <= max_block_size:
             raise ValueError(
-                f"DFlash2 draft token count must be between 2 and {checkpoint_config.block_size}."
+                f"Draft token count must be between 2 and {max_block_size}."
             )
         server_args.speculative_eagle_topk = 1
         server_args.speculative_num_steps = self.block_size - 1
@@ -81,8 +82,9 @@ class DFlash2Worker(SpeculativeWorker):
         super().__init__(server_args)
         self.dflash2_config = self.draft_model_runner.model.dflash_config
         for layer in self.draft_model_runner.model.layers:
-            layer.attention_conv.block_size = self.block_size
-            layer.mlp_conv.block_size = self.block_size
+            for conv in (layer.attention_conv, layer.mlp_conv):
+                if conv is not None:
+                    conv.block_size = self.block_size
         _validate_model_pair(
             draft_config=self.draft_model_runner.get_config(),
             target_config=self.target_model_runner.get_config(),
@@ -168,11 +170,11 @@ class DFlash2Worker(SpeculativeWorker):
     @torch.inference_mode()
     def _forward_prefill(self, batch: ScheduleBatch) -> BatchResult:
         if not all(sequence.sampling_params.is_greedy for sequence in batch):
-            raise ValueError("DFlash2 currently supports greedy requests only.")
+            raise ValueError("Block drafts currently support greedy requests only.")
 
         output = self.target_model_runner.forward(batch)
         if output.aux_hidden_states is None:
-            raise RuntimeError("DFlash2 target prefill returned no captured states.")
+            raise RuntimeError("Target prefill returned no captured states for the draft.")
         self.draft_model_runner.model.materialize_target_kv(
             target_hidden=torch.cat(output.aux_hidden_states, dim=-1),
             positions=batch.position_ids,
@@ -264,23 +266,11 @@ class DFlash2Worker(SpeculativeWorker):
             input_embeds=embeddings,
         ).view(batch_size, block, -1)
 
-        prediction_hidden = draft_hidden[:, 1:]
-        candidate_ids, unary_logits = self.draft_model_runner.model.compute_candidates(
-            prediction_hidden.reshape(-1, prediction_hidden.shape[-1]),
+        self.draft_model_runner.model.sample_proposals(
+            draft_hidden[:, 1:],
             self.target_model_runner.model.lm_head.weight,
-        )
-        top_k = self.dflash2_config.selector_top_k
-        candidate_ids = candidate_ids.view(batch_size, block - 1, top_k)
-        pairwise = (
-            self.draft_model_runner.model.candidate_selector.compute_pairwise_scores(
-                candidate_ids=candidate_ids,
-                hidden_states=prediction_hidden,
-                anchor_token_ids=self._block_ids[:batch_size, 0],
-            )
-        )
-        dflash2_selector_greedy_walk(
-            candidate_ids, unary_logits.view(batch_size, block - 1, top_k),
-            pairwise, self._proposals[:batch_size],
+            self._block_ids[:batch_size, 0],
+            self._proposals[:batch_size],
         )
 
         candidates = self._candidates[:batch_size]

--- a/python/sfllm/spec_decoding/dspark_worker.py
+++ b/python/sfllm/spec_decoding/dspark_worker.py
@@ -1,0 +1,21 @@
+"""DSpark proposals on the shared block-draft verification and KV protocol."""
+
+from sfllm.models.dspark import DSparkConfig
+from sfllm.spec_decoding.dflash2_worker import DFlash2Worker
+
+
+class DSparkWorker(DFlash2Worker):
+    config_cls = DSparkConfig
+    checkpoint_verify_extra = 1
+
+    def __init__(self, server_args):
+        top_k = server_args.speculative_dspark_topk
+        if top_k != -1 and top_k <= 0:
+            raise ValueError("DSpark top-k must be -1 (original DSpark) or a positive integer.")
+        super().__init__(server_args)
+        model = self.draft_model_runner.model
+        if top_k > 0 and model.dflash_config.markov_head_type != "vanilla":
+            raise ValueError("DSpark top-k proposals require a vanilla Markov head.")
+        if top_k > int(model.config.vocab_size):
+            raise ValueError("DSpark top-k exceeds the vocabulary size.")
+        model.proposal_top_k = top_k

--- a/python/sfllm/spec_decoding/spec_common.py
+++ b/python/sfllm/spec_decoding/spec_common.py
@@ -50,6 +50,7 @@ class SpeculativeAlgorithm(IntEnum):
     EAGLE = auto()
     EAGLE3 = auto()
     DFLASH2 = auto()
+    DSPARK = auto()
 
     def is_none(self):
         return self == SpeculativeAlgorithm.NONE
@@ -66,6 +67,7 @@ class SpeculativeAlgorithm(IntEnum):
             "EAGLE": SpeculativeAlgorithm.EAGLE,
             "EAGLE3": SpeculativeAlgorithm.EAGLE3,
             "DFLASH2": SpeculativeAlgorithm.DFLASH2,
+            "DSPARK": SpeculativeAlgorithm.DSPARK,
             None: SpeculativeAlgorithm.NONE,
         }
         if name is not None:


### PR DESCRIPTION
Add `--speculative-algorithm dspark` for Qwen3 DSpark checkpoints with Qwen3/Qwen3.5 targets. Reuse DFlash2's backbone, KV handling, verification, overlap and CUDA Graph execution.

Supports vanilla, gated and RNN Markov heads. `--speculative-dspark-topk` defaults to `-1` (full vocabulary); positive values enable batched top-k proposals for vanilla heads. Decoding is greedy with a fixed block size; confidence-based planning is not included.
